### PR TITLE
Adds support for more of the rendering pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,7 @@ jspm_packages
 .node_repl_history
 
 # Jest cache
-.jest
+.jest/
 
 # TS build files
 build

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "files.exclude": {
+    "**/.git": true,
+    "**/.DS_Store": true,
+    "**/.jest": true,
+    "**/node_modules": true
+  }
+}

--- a/jsx-render.svg
+++ b/jsx-render.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<svg width="600" height="400" xmlns="http://www.w3.org/2000/svg" version="1.1">
+  <rect x="40" y="40" width="200" height="200" fill-opacity="0.1" stroke-width="1" stroke="black"/>  <rect x="0" y="0" width="20" height="20" fill-opacity="0.1" stroke-width="1" stroke="black"/>  <rect x="0" y="0" width="20" height="20" fill-opacity="0.1" stroke-width="1" stroke="black"/>  <rect x="0" y="0" width="20" height="20" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+</svg>

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "preset": "react-native"
   },
   "dependencies": {
+    "ts-lint": "^4.5.1",
     "yoga-layout": "^1.5.0"
   }
 }

--- a/simple.svg
+++ b/simple.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<svg width="1024" height="768" xmlns="http://www.w3.org/2000/svg" version="1.1">
+  <rect x="20" y="20" width="600" height="400" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+</svg>

--- a/src/_tests/__snapshots__/_node-to-svg.test.ts.snap
+++ b/src/_tests/__snapshots__/_node-to-svg.test.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`nodeToSVG handles a simple square 1`] = `"<rect x=\\"0\\" y=\\"0\\" width=\\"600\\" height=\\"400\\" fill-opacity=\\"0.1\\" stroke-width=\\"1\\" stroke=\\"black\\"/>"`;

--- a/src/_tests/__snapshots__/_tree-to-svg-sub-funcs.test.ts.snap
+++ b/src/_tests/__snapshots__/_tree-to-svg-sub-funcs.test.ts.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`svgWrapper wraps whatever text you pass into it with an SVG schema 1`] = `
+"<?xml version=\\"1.0\\" encoding=\\"UTF-8\\" ?>
+<svg width=\\"444\\" height=\\"555\\" xmlns=\\"http://www.w3.org/2000/svg\\" version=\\"1.1\\">
+  [My Body]
+</svg>
+"
+`;

--- a/src/_tests/__snapshots__/_tree-to-svg.test.ts.snap
+++ b/src/_tests/__snapshots__/_tree-to-svg.test.ts.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`treeToSVG wraps whatever text you pass into it with an SVG schema 1`] = `
+"<?xml version=\\"1.0\\" encoding=\\"UTF-8\\" ?>
+<svg width=\\"1024\\" height=\\"768\\" xmlns=\\"http://www.w3.org/2000/svg\\" version=\\"1.1\\">
+  <rect x=\\"20\\" y=\\"20\\" width=\\"600\\" height=\\"400\\" fill-opacity=\\"0.1\\" stroke-width=\\"1\\" stroke=\\"black\\"/>
+</svg>
+"
+`;

--- a/src/_tests/__snapshots__/render.test.tsx.snap
+++ b/src/_tests/__snapshots__/render.test.tsx.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`handles some simple JSX 1`] = `
+"<?xml version=\\"1.0\\" encoding=\\"UTF-8\\" ?>
+<svg width=\\"600\\" height=\\"400\\" xmlns=\\"http://www.w3.org/2000/svg\\" version=\\"1.1\\">
+  <rect x=\\"40\\" y=\\"40\\" width=\\"200\\" height=\\"200\\" fill-opacity=\\"0.1\\" stroke-width=\\"1\\" stroke=\\"black\\"/>  <rect x=\\"0\\" y=\\"0\\" width=\\"20\\" height=\\"20\\" fill-opacity=\\"0.1\\" stroke-width=\\"1\\" stroke=\\"black\\"/>  <rect x=\\"0\\" y=\\"0\\" width=\\"20\\" height=\\"20\\" fill-opacity=\\"0.1\\" stroke-width=\\"1\\" stroke=\\"black\\"/>  <rect x=\\"0\\" y=\\"0\\" width=\\"20\\" height=\\"20\\" fill-opacity=\\"0.1\\" stroke-width=\\"1\\" stroke=\\"black\\"/>
+</svg>
+"
+`;

--- a/src/_tests/_component-to-node.test.ts
+++ b/src/_tests/_component-to-node.test.ts
@@ -1,0 +1,31 @@
+import * as yoga from "yoga-layout"
+
+import componentToNode from "../component-to-node"
+
+describe("componentToNode", () => {
+    it("generates the width for a simple component", () => {
+      const component = {
+        type: "View",
+        props: {
+          style: {
+            width: 300,
+            height: 40
+          }
+        },
+        children: null
+      }
+
+      const settings = {
+        width: 1024,
+        height: 768
+      }
+
+      const node = componentToNode(component, settings)
+      node.calculateLayout(yoga.UNDEFINED, yoga.UNDEFINED, yoga.DIRECTION_INHERIT)
+
+      expect(node.getComputedWidth()).toEqual(300)
+      expect(node.getComputedHeight()).toEqual(40)
+
+      node.free()
+    })
+})

--- a/src/_tests/_node-to-svg.test.ts
+++ b/src/_tests/_node-to-svg.test.ts
@@ -1,0 +1,23 @@
+import * as yoga from "yoga-layout"
+
+import nodeToSVG from "../node-to-svg"
+
+describe("nodeToSVG", () => {
+    it("handles a simple square", () => {
+      const rootNode = yoga.Node.create()
+      rootNode.setWidth(600)
+      rootNode.setHeight(400)
+      rootNode.setDisplay(yoga.DISPLAY_FLEX)
+      rootNode.setFlexDirection(yoga.FLEX_DIRECTION_ROW)
+
+      const settings = {
+        width: 1024,
+        height: 768
+      }
+
+      const results = nodeToSVG(rootNode, null, settings)
+      expect(results).toMatchSnapshot()
+
+      rootNode.free()
+    })
+})

--- a/src/_tests/_tree-to-svg-sub-funcs.test.ts
+++ b/src/_tests/_tree-to-svg-sub-funcs.test.ts
@@ -1,0 +1,68 @@
+const nodeToSVG = jest.fn()
+jest.mock("../node-to-svg.ts", () => ({ default: nodeToSVG }))
+
+import * as yoga from "yoga-layout"
+import { recurseTree, svgWrapper } from "../tree-to-svg"
+
+describe("svgWrapper", () => {
+    it("wraps whatever text you pass into it with an SVG schema", () => {
+      const body = "[My Body]"
+      const settings = {
+        width: 444,
+        height: 555
+      }
+
+      const results = svgWrapper(body, settings)
+      expect(results).toMatchSnapshot()
+    })
+})
+
+describe("recurseTree", () => {
+    beforeEach(() => {
+      nodeToSVG.mockReset()
+    })
+
+    it("Calls nodeToSVG for it's first node", () => {
+      const children = []
+      const fakeNode: any = {
+        getChild: (index) => children[index],
+        getChildCount: () => children.length,
+      }
+      const settings = {
+        width: 1024,
+        height: 768
+      }
+      const results = recurseTree(0, fakeNode, null, settings)
+      expect(nodeToSVG.mock.calls.length).toEqual(1)
+    })
+
+    it("Calls nodeToSVG for it's children nodes", () => {
+      const children = [] as any[]
+      const root: any = {
+        getChild: (index) => children[index],
+        getChildCount: () => children.length,
+        id: "root"
+      }
+      const fakeNode2: any = {
+        getChild: (index) => null,
+        getChildCount: () => 0,
+        id: "2"
+      }
+
+      const fakeNode3: any = {
+        getChild: (index) => null,
+        getChildCount: () => 0,
+        id: "3"
+      }
+      children.push(fakeNode2)
+      children.push(fakeNode3)
+
+      const settings = {
+        width: 1024,
+        height: 768
+      }
+
+      const results = recurseTree(0, root, null, settings)
+      expect(nodeToSVG.mock.calls.length).toEqual(3)
+    })
+})

--- a/src/_tests/_tree-to-svg.test.ts
+++ b/src/_tests/_tree-to-svg.test.ts
@@ -1,0 +1,28 @@
+import * as fs from "fs"
+import * as yoga from "yoga-layout"
+
+import treeToSVG from "../tree-to-svg"
+
+describe("treeToSVG", () => {
+    it("wraps whatever text you pass into it with an SVG schema", () => {
+      jest.unmock("../node-to-svg")
+
+      const rootNode = yoga.Node.create()
+      rootNode.setWidth(600)
+      rootNode.setHeight(400)
+      rootNode.setMargin(yoga.EDGE_ALL, 20)
+      rootNode.setDisplay(yoga.DISPLAY_FLEX)
+      rootNode.setFlexDirection(yoga.FLEX_DIRECTION_ROW)
+
+      const settings = {
+        width: 1024,
+        height: 768
+      }
+
+      const results = treeToSVG(rootNode, settings)
+      expect(results).toMatchSnapshot()
+      fs.writeFileSync("simple.svg", results)
+
+      rootNode.freeRecursive()
+    })
+})

--- a/src/_tests/index.test.ts
+++ b/src/_tests/index.test.ts
@@ -1,7 +1,0 @@
-import hello from "../"
-
-describe("hello", () => {
-    it("does something", () => {
-        expect("a").toEqual("a")
-    })
-})

--- a/src/_tests/render.test.tsx
+++ b/src/_tests/render.test.tsx
@@ -1,13 +1,32 @@
 import * as React from "react"
-import { Text } from "react-native"
+import { View } from "react-native"
 import * as renderer from "react-test-renderer"
 
-import ourRenderer from "../"
+import componentTreeToNodeTree from "../component-tree-to-nodes"
+import treeToSVG from "../tree-to-svg"
 
-describe("Fixtures", () => {
-  it("does some simple JSX", () => {
-    const artist = renderer.create(<Text />)
-    ourRenderer(1024, 768, artist.toJSON())
-    // expect(artist.toJSON()).toMatchSnapshot()
-  })
+import * as fs from "fs"
+import * as yoga from "yoga-layout"
+
+it("handles some simple JSX", () => {
+  const jsx = (
+    <View style={{width: 200, height: 200, marginLeft: 40, marginTop: 40, paddingLeft: 20}}>
+      <View style={{width: 20, height: 20}}/>
+      <View style={{width: 20, height: 20}}/>
+      <View style={{width: 20, height: 20}}/>
+    </View>
+  )
+  const component = renderer.create(jsx).toJSON()
+  const settings = {
+    width:  600,
+    height: 400,
+  }
+  console.log(component)
+  const rootNode = componentTreeToNodeTree(component, settings)
+  const results = treeToSVG(rootNode, settings)
+
+  fs.writeFileSync("jsx-render.svg", results)
+  expect(results).toMatchSnapshot()
+
+  rootNode.freeRecursive()
 })

--- a/src/ambient.d.ts
+++ b/src/ambient.d.ts
@@ -5,6 +5,7 @@
 declare module "yoga-layout" {
 
   // https://github.com/facebook/yoga/blob/master/javascript/sources/YGEnums.js
+  const UNDEFINED: number
 
   const ALIGN_COUNT = 8
   const ALIGN_AUTO = 0
@@ -15,6 +16,19 @@ declare module "yoga-layout" {
   const ALIGN_BASELINE = 5
   const ALIGN_SPACE_BETWEEN = 6
   const ALIGN_SPACE_AROUND = 7
+
+ /** Do not use this in your code */
+  enum Align {
+    Count = 8,
+    Auto = 0,
+    FlexStart = 1,
+    Center = 2,
+    FlexEnd = 3,
+    Stretch = 4,
+    Baseline = 5,
+    SpaceBetween = 6,
+    SpaceAround = 7,
+  }
 
   const DIMENSION_COUNT = 2
   const DIMENSION_WIDTH = 0
@@ -154,6 +168,13 @@ declare module "yoga-layout" {
   }
 
   class Layout {
+    left: number
+    right: number
+    top: number
+    bottom: number
+    width: number
+    height: number
+
     constructor(left: number, right: number, top: number, bottom: number, width: number, height: number)
     fromJS(expose: () => void)
     toString(): string
@@ -166,12 +187,18 @@ declare module "yoga-layout" {
 
   class Size {
     static fromJS(Sizeable): Size
+
+    width: number
+    height: number
     constructor(width: number, height: number)
     fromJS(expose: () => void)
     toString(): string
   }
 
   class Value {
+    unit: Unit
+    value: any
+
     constructor(unit: Unit, value: any)
 
     fromJS(expose: () => void)
@@ -191,9 +218,10 @@ declare module "yoga-layout" {
     setMaxWidth(height: number)
     setMaxHeight(height: number)
     setPadding(edge: Edge, value: number)
+    setMargin(edge: Edge, value: number) // maybe?
     setDisplay(display: Display)
 
-    setFlex(direction: Direction)
+    setFlex(ordinal: number)
     setFlexDirection(direct: FlexDirection)
 
     insertChild(node: NodeInstance, index: number)
@@ -204,15 +232,16 @@ declare module "yoga-layout" {
     getComputedTop(): number
     getComputedHeight(): number
 
-    getComputedLayout(): Layout
-
     getChild(index: number): NodeInstance
     getChildCount(): number
 
     free()
     freeRecursive()
 
-    calculateLayout(width: number, height: number, Direction)
+    // Triggers a layout pass, but doesn't give you the results
+    calculateLayout(width: number, height: number, direction: Direction)
+    // Generates the layout
+    getComputedLayout(): Layout
   }
 
   interface NodeFactory {

--- a/src/component-to-node.ts
+++ b/src/component-to-node.ts
@@ -1,0 +1,46 @@
+import * as yoga from "yoga-layout"
+import { Component, Settings } from "./index"
+
+const componentToNode = (component: Component, settings: Settings) => {
+  // Do we need to pass in the parent node too?
+  const node = yoga.Node.create()
+  if (component.props && component.props.style) {
+    let style = component.props.style
+
+    // TODO: merge like RN stylesheets would
+    if (component.props.style instanceof Array) {
+      style = component.props.style.first
+    }
+
+    if (style.width) { node.setWidth(style.width) }
+    if (style.height) { node.setHeight(style.height) }
+
+    if (style.marginTop) { node.setMargin(yoga.EDGE_TOP, style.marginTop ) }
+    if (style.marginBottom) { node.setMargin(yoga.EDGE_BOTTOM, style.marginBottom ) }
+    if (style.marginLeft) { node.setMargin(yoga.EDGE_LEFT, style.marginLeft ) }
+    if (style.marginRight) { node.setMargin(yoga.EDGE_RIGHT, style.marginRight ) }
+
+    if (style.paddingTop) { node.setPadding(yoga.EDGE_TOP, style.paddingTop ) }
+    if (style.paddingBottom) { node.setPadding(yoga.EDGE_BOTTOM, style.paddingBottom ) }
+    if (style.paddingLeft) { node.setPadding(yoga.EDGE_LEFT, style.paddingLeft ) }
+    if (style.paddingRight) { node.setPadding(yoga.EDGE_RIGHT, style.paddingRight ) }
+
+    if (style.flex) { node.setFlex(style.flex) }
+
+    if (style.alignItems) {
+      let alignment: yoga.Align = 0
+      switch (style.alignItems) {
+        case "center":
+          alignment = yoga.ALIGN_CENTER
+          break
+
+        default:
+          break
+      }
+    }
+  }
+
+  return node
+}
+
+export default componentToNode

--- a/src/component-tree-to-nodes.ts
+++ b/src/component-tree-to-nodes.ts
@@ -1,0 +1,21 @@
+import * as yoga from "yoga-layout"
+
+import componentToNode from "./component-to-node"
+import { Component, Settings } from "./index"
+
+const treeToNodes = (root: Component, settings: Settings) => recurseTree(root, settings)
+export default treeToNodes
+
+export const recurseTree = (component: Component, settings: Settings) => {
+  const node = componentToNode(component, settings)
+
+  if (component.children) {
+    for (let index = 0; index < component.children.length; index++) {
+      const childComponent = component.children[index]
+      const childNode = recurseTree(childComponent, settings)
+      node.insertChild(childNode, index)
+    }
+  }
+
+  return node
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,11 +3,16 @@ import * as yoga from "yoga-layout"
 export interface Component {
     type: string,
     props: any,
-    children: Component[]
+    children: Component[] | null
 }
 
-export default function hello(width: number, height: number, json: Component) {
+export interface Settings {
+    width: number
+    height: number
+}
 
+export default function hello(settings: Settings, json: Component) {
+    const {height, width} = settings
     const rootNode = yoga.Node.create()
     rootNode.setWidth(width)
     rootNode.setHeight(height)

--- a/src/node-to-svg.ts
+++ b/src/node-to-svg.ts
@@ -1,0 +1,31 @@
+import * as yoga from "yoga-layout"
+import { Settings } from "./index"
+
+const nodeToSVG = (node: yoga.NodeInstance, parent: yoga.NodeInstance | null, settings: Settings) => {
+  // Do we need to pass in the parent node too?
+  const outerWidth = parent ? parent.getComputedWidth() : settings.width
+  const outerHeight = parent ? parent.getComputedWidth() : settings.height
+
+  node.calculateLayout(outerWidth, outerHeight, yoga.DIRECTION_INHERIT)
+  const layout = node.getComputedLayout()
+  const attributes = {
+    "fill-opacity": "0.1",
+    "stroke-width": "1",
+    "stroke": "black"
+  }
+  console.log(layout.toString())
+  return svgRect(layout.left, layout.top, layout.width, layout.height, attributes)
+}
+
+const svgRect = (x, y, w, h, settings) => {
+  let attributes = ""
+  for (const key in settings) {
+    if (settings.hasOwnProperty(key)) {
+      const element = settings[key]
+      attributes += ` ${key}="${element}"`
+    }
+  }
+  return `<rect x="${x}" y="${y}" width="${w}" height="${h}"${attributes}/>`
+}
+
+export default nodeToSVG

--- a/src/tree-to-svg.ts
+++ b/src/tree-to-svg.ts
@@ -1,0 +1,26 @@
+import * as yoga from "yoga-layout"
+import { Settings } from "./index"
+import nodeToSVG from "./node-to-svg"
+
+export const recurseTree =
+  (indent: number, root: yoga.NodeInstance, parent: yoga.NodeInstance | null, settings: Settings) => {
+
+  let nodeString = nodeToSVG(root, parent, settings)
+  for (let index = 0; index < root.getChildCount(); index++) {
+    const child = root.getChild(index)
+    nodeString += "  " + recurseTree(indent + 1, child, root, settings)
+  }
+  return nodeString
+}
+
+export const svgWrapper = (bodyText: string, settings: Settings) =>
+`<?xml version="1.0" encoding="UTF-8" ?>
+<svg width="${settings.width}" height="${settings.height}" xmlns="http://www.w3.org/2000/svg" version="1.1">
+  ${bodyText}
+</svg>
+`
+
+const treeToSVG = (root: yoga.NodeInstance, settings: Settings) =>
+  svgWrapper( recurseTree(0, root, null, settings), settings)
+
+export default treeToSVG

--- a/tslint.json
+++ b/tslint.json
@@ -3,6 +3,18 @@
     "tslint:recommended"
   ],
   "rules": {
+    // These can be ignored, I started a PR to fix them in schemastore but damn, it was a timesink with no obvious end
+    "completed-docs": [
+      true,
+      {
+        "functions": {
+          "visibilities" : ["exported"]
+        },
+        "methods": {
+          "visibilities" : ["exported"]
+        }
+      }
+    ],
     "no-console": [
       false
     ],
@@ -30,8 +42,7 @@
     ],
     "switch-default": false,
     "trailing-comma": [
-      true,
-      { "multiline": "always", "singleline": "never" }
+      false
     ]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -249,7 +249,7 @@ babel-cli@^6.24.1:
   optionalDependencies:
     chokidar "^1.6.1"
 
-babel-code-frame@^6.22.0:
+babel-code-frame@^6.20.0, babel-code-frame@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.22.0.tgz#027620bee567a88c32561574e7fd0801d33118e4"
   dependencies:
@@ -1436,7 +1436,7 @@ detect-indent@^4.0.0:
   dependencies:
     repeating "^2.0.0"
 
-diff@^3.0.0, diff@^3.1.0, diff@^3.2.0:
+diff@^3.0.0, diff@^3.0.1, diff@^3.1.0, diff@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
 
@@ -4069,7 +4069,7 @@ resolve@1.1.7, resolve@~1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-resolve@^1.2.0, resolve@^1.3.2:
+resolve@^1.1.7, resolve@^1.2.0, resolve@^1.3.2:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.3.tgz#655907c3469a8680dc2de3a275a8fdd69691f0e5"
   dependencies:
@@ -4565,6 +4565,19 @@ ts-jest@^20.0.0:
     tsconfig "^6.0.0"
     yargs "^8.0.1"
 
+ts-lint@^4.5.1:
+  version "4.5.1"
+  resolved "https://registry.yarnpkg.com/ts-lint/-/ts-lint-4.5.1.tgz#9c22b7b7b862b67324dd1bd213a845c03a7fb8c0"
+  dependencies:
+    babel-code-frame "^6.20.0"
+    colors "^1.1.2"
+    diff "^3.0.1"
+    findup-sync "~0.3.0"
+    glob "^7.1.1"
+    optimist "~0.6.0"
+    resolve "^1.1.7"
+    tsutils "^1.1.0"
+
 ts-node@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-3.0.4.tgz#a1475ebf24fd4e2ee2fba8b1aa1605b977bde506"
@@ -4610,7 +4623,7 @@ tsscmp@1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/tsscmp/-/tsscmp-1.0.5.tgz#7dc4a33af71581ab4337da91d85ca5427ebd9a97"
 
-tsutils@^1.8.0:
+tsutils@^1.1.0, tsutils@^1.8.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-1.9.1.tgz#b9f9ab44e55af9681831d5f28d0aeeaf5c750cb0"
 


### PR DESCRIPTION
Currently it doesn't take the parent's x, y into account when positioning the objects (I assume I need to read the SVG spec and find  some kind of grouping mechanism) - **however** it will render a JSX component into a working SVG:

![screen shot 2017-05-19 at 12 54 34](https://cloud.githubusercontent.com/assets/49038/26246787/dc0bc842-3c92-11e7-8abb-942b417233bf.png)

---

I should export some SVGs from Sketch to see what they look like.