### PR TITLE
Adds some more examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ jspm_packages
 
 # TS build files
 build
+
+error_log.txt

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,10 @@
+src
+build/_tests
+.vscode
+.babelrc
+.travis.yml
+dangerfile.ts
+jsx-render.svg
+tsconfig.json
+tslint.json
+yarn.lock

--- a/jsx-render.svg
+++ b/jsx-render.svg
@@ -5,14 +5,14 @@
 
  <g transform='translate(40, 40)'>
    <rect x="20" y="0" width="20" height="20" fill-opacity="0.1" stroke-width="1" stroke="black"/>
-   <rect x="40" y="20" width="160" height="40" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+   <rect x="20" y="40" width="160" height="40" fill-opacity="0.1" stroke-width="1" stroke="black"/>
 
-   <g transform='translate(40, 20)'>
+   <g transform='translate(20, 40)'>
      <rect x="10" y="20" width="10" height="10" fill-opacity="0.1" stroke-width="1" stroke="black"/>
-     <rect x="40" y="10" width="10" height="10" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+     <rect x="20" y="40" width="10" height="10" fill-opacity="0.1" stroke-width="1" stroke="black"/>
    </g>
 
-   <rect x="200" y="0" width="20" height="20" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+   <rect x="20" y="80" width="20" height="20" fill-opacity="0.1" stroke-width="1" stroke="black"/>
  </g>
 
 </svg>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-snapshots-svg",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Generate SVG Snapshots of React Native Component Trees",
   "main": "build/index.js",
   "author": "Orta Therox <orta.therox@gmail.com> & Art.sy Inc",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
   "name": "jest-snapshots-svg",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Generate SVG Snapshots of React Native Component Trees",
   "main": "build/index.js",
+  "files": [
+    "build/*"
+  ],
   "author": "Orta Therox <orta.therox@gmail.com> & Art.sy Inc",
   "license": "MIT",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "preset": "react-native"
   },
   "dependencies": {
+    "@types/react-native": "^0.44.3",
     "ts-lint": "^4.5.1",
     "yoga-layout": "^1.5.0"
   }

--- a/src/_tests/__fixtures__/artwork-grid.json
+++ b/src/_tests/__fixtures__/artwork-grid.json
@@ -1,0 +1,443 @@
+{
+  "type": "View",
+  "props": {},
+  "children": [
+    {
+      "type": "View",
+      "props": {
+        "style": {
+          "flexDirection": "row"
+        },
+        "accessibilityLabel": "Artworks Content View"
+      },
+      "children": [
+        {
+          "type": "View",
+          "props": {
+            "style": [
+              {
+                "flexDirection": "column"
+              },
+              {
+                "width": 242.66666666666666,
+                "marginRight": 20
+              }
+            ],
+            "accessibilityLabel": "Section 0"
+          },
+          "children": [
+            {
+              "type": "View",
+              "props": {
+                "accessible": true
+              },
+              "children": [
+                {
+                  "type": "AROpaqueImageView",
+                  "props": {
+                    "style": {
+                      "marginBottom": 10
+                    },
+                    "aspectRatio": 2.18,
+                    "imageURL": "artsy.net/image-url"
+                  },
+                  "children": null
+                },
+                {
+                  "type": "Text",
+                  "props": {
+                    "style": [
+                      {
+                        "fontSize": 17
+                      },
+                      [
+                        {
+                          "fontSize": 12,
+                          "color": "#666666"
+                        },
+                        {
+                          "fontWeight": "bold"
+                        }
+                      ],
+                      {
+                        "fontFamily": "AGaramondPro-Regular"
+                      }
+                    ],
+                    "numberOfLines": 1,
+                    "accessible": true,
+                    "allowFontScaling": true,
+                    "ellipsizeMode": "tail"
+                  },
+                  "children": [
+                    "Guerrilla Girls"
+                  ]
+                },
+                {
+                  "type": "Text",
+                  "props": {
+                    "style": [
+                      {
+                        "fontSize": 17
+                      },
+                      {
+                        "fontSize": 12,
+                        "color": "#666666"
+                      },
+                      {
+                        "fontFamily": "AGaramondPro-Regular"
+                      }
+                    ],
+                    "numberOfLines": 1,
+                    "accessible": true,
+                    "allowFontScaling": true,
+                    "ellipsizeMode": "tail"
+                  },
+                  "children": [
+                    {
+                      "type": "Text",
+                      "props": {
+                        "style": [
+                          {
+                            "fontSize": 17
+                          },
+                          [
+                            {
+                              "fontSize": 12,
+                              "color": "#666666"
+                            },
+                            {
+                              "fontStyle": "italic"
+                            }
+                          ],
+                          {
+                            "fontFamily": "AGaramondPro-Regular"
+                          }
+                        ],
+                        "numberOfLines": 1,
+                        "accessible": true,
+                        "allowFontScaling": true,
+                        "ellipsizeMode": "tail"
+                      },
+                      "children": [
+                        "DO WOMEN STILL HAVE TO BE NAKED TO GET INTO THE MET. MUSEUM"
+                      ]
+                    },
+                    ", 2012"
+                  ]
+                },
+                {
+                  "type": "Text",
+                  "props": {
+                    "style": [
+                      {
+                        "fontSize": 17
+                      },
+                      {
+                        "fontSize": 12,
+                        "color": "#666666"
+                      },
+                      {
+                        "fontFamily": "AGaramondPro-Regular"
+                      }
+                    ],
+                    "numberOfLines": 1,
+                    "accessible": true,
+                    "allowFontScaling": true,
+                    "ellipsizeMode": "tail"
+                  },
+                  "children": [
+                    "Whitechapel Gallery"
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "View",
+          "props": {
+            "style": [
+              {
+                "flexDirection": "column"
+              },
+              {
+                "width": 242.66666666666666,
+                "marginRight": 20
+              }
+            ],
+            "accessibilityLabel": "Section 1"
+          },
+          "children": [
+            {
+              "type": "View",
+              "props": {
+                "accessible": true
+              },
+              "children": [
+                {
+                  "type": "AROpaqueImageView",
+                  "props": {
+                    "style": {
+                      "marginBottom": 10
+                    },
+                    "aspectRatio": 2.18,
+                    "imageURL": "artsy.net/image-url"
+                  },
+                  "children": null
+                },
+                {
+                  "type": "Text",
+                  "props": {
+                    "style": [
+                      {
+                        "fontSize": 17
+                      },
+                      [
+                        {
+                          "fontSize": 12,
+                          "color": "#666666"
+                        },
+                        {
+                          "fontWeight": "bold"
+                        }
+                      ],
+                      {
+                        "fontFamily": "AGaramondPro-Regular"
+                      }
+                    ],
+                    "numberOfLines": 1,
+                    "accessible": true,
+                    "allowFontScaling": true,
+                    "ellipsizeMode": "tail"
+                  },
+                  "children": [
+                    "Guerrilla Girls"
+                  ]
+                },
+                {
+                  "type": "Text",
+                  "props": {
+                    "style": [
+                      {
+                        "fontSize": 17
+                      },
+                      {
+                        "fontSize": 12,
+                        "color": "#666666"
+                      },
+                      {
+                        "fontFamily": "AGaramondPro-Regular"
+                      }
+                    ],
+                    "numberOfLines": 1,
+                    "accessible": true,
+                    "allowFontScaling": true,
+                    "ellipsizeMode": "tail"
+                  },
+                  "children": [
+                    {
+                      "type": "Text",
+                      "props": {
+                        "style": [
+                          {
+                            "fontSize": 17
+                          },
+                          [
+                            {
+                              "fontSize": 12,
+                              "color": "#666666"
+                            },
+                            {
+                              "fontStyle": "italic"
+                            }
+                          ],
+                          {
+                            "fontFamily": "AGaramondPro-Regular"
+                          }
+                        ],
+                        "numberOfLines": 1,
+                        "accessible": true,
+                        "allowFontScaling": true,
+                        "ellipsizeMode": "tail"
+                      },
+                      "children": [
+                        "DO WOMEN STILL HAVE TO BE NAKED TO GET INTO THE MET. MUSEUM"
+                      ]
+                    },
+                    ", 2012"
+                  ]
+                },
+                {
+                  "type": "Text",
+                  "props": {
+                    "style": [
+                      {
+                        "fontSize": 17
+                      },
+                      {
+                        "fontSize": 12,
+                        "color": "#666666"
+                      },
+                      {
+                        "fontFamily": "AGaramondPro-Regular"
+                      }
+                    ],
+                    "numberOfLines": 1,
+                    "accessible": true,
+                    "allowFontScaling": true,
+                    "ellipsizeMode": "tail"
+                  },
+                  "children": [
+                    "Whitechapel Gallery"
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "View",
+          "props": {
+            "style": [
+              {
+                "flexDirection": "column"
+              },
+              {
+                "width": 242.66666666666666,
+                "marginRight": 0
+              }
+            ],
+            "accessibilityLabel": "Section 2"
+          },
+          "children": [
+            {
+              "type": "View",
+              "props": {
+                "accessible": true
+              },
+              "children": [
+                {
+                  "type": "AROpaqueImageView",
+                  "props": {
+                    "style": {
+                      "marginBottom": 10
+                    },
+                    "aspectRatio": 2.18,
+                    "imageURL": "artsy.net/image-url"
+                  },
+                  "children": null
+                },
+                {
+                  "type": "Text",
+                  "props": {
+                    "style": [
+                      {
+                        "fontSize": 17
+                      },
+                      [
+                        {
+                          "fontSize": 12,
+                          "color": "#666666"
+                        },
+                        {
+                          "fontWeight": "bold"
+                        }
+                      ],
+                      {
+                        "fontFamily": "AGaramondPro-Regular"
+                      }
+                    ],
+                    "numberOfLines": 1,
+                    "accessible": true,
+                    "allowFontScaling": true,
+                    "ellipsizeMode": "tail"
+                  },
+                  "children": [
+                    "Guerrilla Girls"
+                  ]
+                },
+                {
+                  "type": "Text",
+                  "props": {
+                    "style": [
+                      {
+                        "fontSize": 17
+                      },
+                      {
+                        "fontSize": 12,
+                        "color": "#666666"
+                      },
+                      {
+                        "fontFamily": "AGaramondPro-Regular"
+                      }
+                    ],
+                    "numberOfLines": 1,
+                    "accessible": true,
+                    "allowFontScaling": true,
+                    "ellipsizeMode": "tail"
+                  },
+                  "children": [
+                    {
+                      "type": "Text",
+                      "props": {
+                        "style": [
+                          {
+                            "fontSize": 17
+                          },
+                          [
+                            {
+                              "fontSize": 12,
+                              "color": "#666666"
+                            },
+                            {
+                              "fontStyle": "italic"
+                            }
+                          ],
+                          {
+                            "fontFamily": "AGaramondPro-Regular"
+                          }
+                        ],
+                        "numberOfLines": 1,
+                        "accessible": true,
+                        "allowFontScaling": true,
+                        "ellipsizeMode": "tail"
+                      },
+                      "children": [
+                        "DO WOMEN STILL HAVE TO BE NAKED TO GET INTO THE MET. MUSEUM"
+                      ]
+                    },
+                    ", 2012"
+                  ]
+                },
+                {
+                  "type": "Text",
+                  "props": {
+                    "style": [
+                      {
+                        "fontSize": 17
+                      },
+                      {
+                        "fontSize": 12,
+                        "color": "#666666"
+                      },
+                      {
+                        "fontFamily": "AGaramondPro-Regular"
+                      }
+                    ],
+                    "numberOfLines": 1,
+                    "accessible": true,
+                    "allowFontScaling": true,
+                    "ellipsizeMode": "tail"
+                  },
+                  "children": [
+                    "Whitechapel Gallery"
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/_tests/__snapshots__/_node-instance-count.test.tsx.svg
+++ b/src/_tests/__snapshots__/_node-instance-count.test.tsx.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<svg width="320" height="480" xmlns="http://www.w3.org/2000/svg" version="1.1">
+
+ <rect x="0" y="0" width="320" height="480" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+
+ <g transform='translate(0, 0)'>
+   <rect x="0" y="330" width="50" height="50" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+   <rect x="0" y="380" width="50" height="50" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+   <rect x="0" y="430" width="50" height="50" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+ </g>
+
+</svg>

--- a/src/_tests/__snapshots__/render.test.tsx.snap
+++ b/src/_tests/__snapshots__/render.test.tsx.snap
@@ -8,14 +8,14 @@ exports[`handles some simple JSX 1`] = `
 
  <g transform='translate(40, 40)'>
    <rect x=\\"20\\" y=\\"0\\" width=\\"20\\" height=\\"20\\" fill-opacity=\\"0.1\\" stroke-width=\\"1\\" stroke=\\"black\\"/>
-   <rect x=\\"40\\" y=\\"20\\" width=\\"160\\" height=\\"40\\" fill-opacity=\\"0.1\\" stroke-width=\\"1\\" stroke=\\"black\\"/>
+   <rect x=\\"20\\" y=\\"40\\" width=\\"160\\" height=\\"40\\" fill-opacity=\\"0.1\\" stroke-width=\\"1\\" stroke=\\"black\\"/>
 
-   <g transform='translate(40, 20)'>
+   <g transform='translate(20, 40)'>
      <rect x=\\"10\\" y=\\"20\\" width=\\"10\\" height=\\"10\\" fill-opacity=\\"0.1\\" stroke-width=\\"1\\" stroke=\\"black\\"/>
-     <rect x=\\"40\\" y=\\"10\\" width=\\"10\\" height=\\"10\\" fill-opacity=\\"0.1\\" stroke-width=\\"1\\" stroke=\\"black\\"/>
+     <rect x=\\"20\\" y=\\"40\\" width=\\"10\\" height=\\"10\\" fill-opacity=\\"0.1\\" stroke-width=\\"1\\" stroke=\\"black\\"/>
    </g>
 
-   <rect x=\\"200\\" y=\\"0\\" width=\\"20\\" height=\\"20\\" fill-opacity=\\"0.1\\" stroke-width=\\"1\\" stroke=\\"black\\"/>
+   <rect x=\\"20\\" y=\\"80\\" width=\\"20\\" height=\\"20\\" fill-opacity=\\"0.1\\" stroke-width=\\"1\\" stroke=\\"black\\"/>
  </g>
 
 </svg>

--- a/src/_tests/__snapshots__/render.test.tsx.svg
+++ b/src/_tests/__snapshots__/render.test.tsx.svg
@@ -5,14 +5,14 @@
 
  <g transform='translate(40, 40)'>
    <rect x="20" y="0" width="20" height="20" fill-opacity="0.1" stroke-width="1" stroke="black"/>
-   <rect x="40" y="20" width="160" height="40" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+   <rect x="20" y="40" width="160" height="40" fill-opacity="0.1" stroke-width="1" stroke="black"/>
 
-   <g transform='translate(40, 20)'>
+   <g transform='translate(20, 40)'>
      <rect x="10" y="20" width="10" height="10" fill-opacity="0.1" stroke-width="1" stroke="black"/>
-     <rect x="40" y="10" width="10" height="10" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+     <rect x="20" y="40" width="10" height="10" fill-opacity="0.1" stroke-width="1" stroke="black"/>
    </g>
 
-   <rect x="200" y="0" width="20" height="20" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+   <rect x="20" y="80" width="20" height="20" fill-opacity="0.1" stroke-width="1" stroke="black"/>
  </g>
 
 </svg>

--- a/src/_tests/_component-to-node.test.ts
+++ b/src/_tests/_component-to-node.test.ts
@@ -17,7 +17,8 @@ describe("componentToNode", () => {
 
       const settings = {
         width: 1024,
-        height: 768
+        height: 768,
+        styleMap: new WeakMap()
       }
 
       const node = componentToNode(component, settings)

--- a/src/_tests/_node-instance-count.test.tsx
+++ b/src/_tests/_node-instance-count.test.tsx
@@ -1,0 +1,33 @@
+import "../index"
+
+import * as yoga from "yoga-layout"
+
+import * as React from "react"
+import { View } from "react-native"
+import * as renderer from "react-test-renderer"
+
+import treeToSVG from "../tree-to-svg"
+
+describe("Counting nodes", () => {
+    it("it is good with memory", () => {
+
+      expect(yoga.getInstanceCount()).toEqual(0)
+
+      const jsx =
+        <View style={{
+          flex: 1,
+          flexDirection: "column",
+          justifyContent: "center",
+          alignItems: "center",
+        }}>
+        <View style={{width: 50, height: 50, backgroundColor: "powderblue"}} />
+        < View style={{width: 50, height: 50, backgroundColor: "skyblue"}} />
+        <View style={{width: 50, height: 50, backgroundColor: "steelblue"}} />
+      </View>
+
+      const component = renderer.create(jsx).toJSON()
+      expect(component).toMatchSVGSnapshot(320, 480)
+
+      expect(yoga.getInstanceCount()).toEqual(0)
+    })
+})

--- a/src/_tests/_node-to-svg.test.ts
+++ b/src/_tests/_node-to-svg.test.ts
@@ -12,7 +12,8 @@ describe("nodeToSVG", () => {
 
       const settings = {
         width: 1024,
-        height: 768
+        height: 768,
+        styleMap: new WeakMap()
       }
 
       const results = nodeToSVG(0, rootNode, settings)

--- a/src/_tests/_tree-to-svg-sub-funcs.test.ts
+++ b/src/_tests/_tree-to-svg-sub-funcs.test.ts
@@ -9,7 +9,9 @@ describe("svgWrapper", () => {
       const body = "[My Body]"
       const settings = {
         width: 444,
-        height: 555
+        height: 555,
+                styleMap: new WeakMap()
+
       }
 
       const results = svgWrapper(body, settings)
@@ -30,7 +32,9 @@ describe("recurseTree", () => {
       }
       const settings = {
         width: 1024,
-        height: 768
+        height: 768,
+        styleMap: new WeakMap()
+
       }
       const results = recurseTree(0, fakeNode, settings)
       expect(nodeToSVG.mock.calls.length).toEqual(1)
@@ -62,7 +66,8 @@ describe("recurseTree", () => {
 
       const settings = {
         width: 1024,
-        height: 768
+        height: 768,
+        styleMap: new WeakMap()
       }
 
       const results = recurseTree(0, root, settings)

--- a/src/_tests/_tree-to-svg.test.ts
+++ b/src/_tests/_tree-to-svg.test.ts
@@ -1,4 +1,3 @@
-// import * as fs from "fs"
 import * as yoga from "yoga-layout"
 
 import treeToSVG from "../tree-to-svg"
@@ -14,7 +13,8 @@ describe("treeToSVG", () => {
 
       const settings = {
         width: 1024,
-        height: 768
+        height: 768,
+        styleMap: new WeakMap()
       }
 
       const results = treeToSVG(rootNode, settings)

--- a/src/_tests/example_layouts/__snapshots__/_align-items.test.tsx.svg
+++ b/src/_tests/example_layouts/__snapshots__/_align-items.test.tsx.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<svg width="320" height="480" xmlns="http://www.w3.org/2000/svg" version="1.1">
+
+ <rect x="0" y="0" width="320" height="480" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+
+ <g transform='translate(0, 0)'>
+   <rect x="0" y="330" width="50" height="50" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+   <rect x="0" y="380" width="50" height="50" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+   <rect x="0" y="430" width="50" height="50" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+ </g>
+
+</svg>

--- a/src/_tests/example_layouts/__snapshots__/_flex-direction.test.tsx.svg
+++ b/src/_tests/example_layouts/__snapshots__/_flex-direction.test.tsx.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<svg width="320" height="480" xmlns="http://www.w3.org/2000/svg" version="1.1">
+
+ <rect x="0" y="0" width="320" height="480" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+
+ <g transform='translate(0, 0)'>
+   <rect x="0" y="0" width="50" height="50" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+   <rect x="50" y="0" width="50" height="50" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+   <rect x="100" y="0" width="50" height="50" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+ </g>
+
+</svg>

--- a/src/_tests/example_layouts/__snapshots__/_justify-contents.test.tsx.svg
+++ b/src/_tests/example_layouts/__snapshots__/_justify-contents.test.tsx.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<svg width="320" height="480" xmlns="http://www.w3.org/2000/svg" version="1.1">
+
+ <rect x="0" y="0" width="320" height="480" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+
+ <g transform='translate(0, 0)'>
+   <rect x="0" y="0" width="50" height="50" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+   <rect x="0" y="215" width="50" height="50" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+   <rect x="0" y="430" width="50" height="50" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+ </g>
+
+</svg>

--- a/src/_tests/example_layouts/_align-items.test.tsx
+++ b/src/_tests/example_layouts/_align-items.test.tsx
@@ -1,0 +1,24 @@
+import "../../index"
+
+import * as React from "react"
+import { View } from "react-native"
+import * as renderer from "react-test-renderer"
+
+// https://facebook.github.io/react-native/docs/flexbox.html
+
+it("Renders three vertically/horizonyally centeredblocks", () => {
+  const jsx =
+      <View style={{
+        flex: 1,
+        flexDirection: "column",
+        justifyContent: "center",
+        alignItems: "center",
+      }}>
+        <View style={{width: 50, height: 50, backgroundColor: "powderblue"}} />
+        <View style={{width: 50, height: 50, backgroundColor: "skyblue"}} />
+        <View style={{width: 50, height: 50, backgroundColor: "steelblue"}} />
+      </View>
+
+  const component = renderer.create(jsx).toJSON()
+  expect(component).toMatchSVGSnapshot(320, 480)
+})

--- a/src/_tests/example_layouts/_flex-direction.test.tsx
+++ b/src/_tests/example_layouts/_flex-direction.test.tsx
@@ -1,0 +1,19 @@
+import "../../index"
+
+import * as React from "react"
+import { View } from "react-native"
+import * as renderer from "react-test-renderer"
+
+// https://facebook.github.io/react-native/docs/flexbox.html
+
+it("Renders three blocks in a row", () => {
+  const jsx =
+    <View style={{flex: 1, flexDirection: "row"}}>
+      <View style={{width: 50, height: 50, backgroundColor: "powderblue"}} />
+      <View style={{width: 50, height: 50, backgroundColor: "skyblue"}} />
+      <View style={{width: 50, height: 50, backgroundColor: "steelblue"}} />
+    </View>
+
+  const component = renderer.create(jsx).toJSON()
+  expect(component).toMatchSVGSnapshot(320, 480)
+})

--- a/src/_tests/example_layouts/_justify-contents.test.tsx
+++ b/src/_tests/example_layouts/_justify-contents.test.tsx
@@ -1,0 +1,19 @@
+import "../../index"
+
+import * as React from "react"
+import { View } from "react-native"
+import * as renderer from "react-test-renderer"
+
+// https://facebook.github.io/react-native/docs/flexbox.html
+
+it("Splits the layout vertically across", () => {
+  const jsx =
+    <View style={{ flex: 1, flexDirection: "column", justifyContent: "space-between" }}>
+      <View style={{ width: 50, height: 50, backgroundColor: "powderblue" }} />
+      <View style={{ width: 50, height: 50, backgroundColor: "skyblue" }} />
+      <View style={{ width: 50, height: 50, backgroundColor: "steelblue" }} />
+    </View>
+
+  const component = renderer.create(jsx).toJSON()
+  expect(component).toMatchSVGSnapshot(320, 480)
+})

--- a/src/_tests/render.test.tsx
+++ b/src/_tests/render.test.tsx
@@ -26,9 +26,11 @@ it("handles some simple JSX", () => {
   const settings = {
     width:  600,
     height: 400,
+    styleMap: new WeakMap()
   }
-  // console.log(component)
+
   const rootNode = componentTreeToNodeTree(component, settings)
+  settings.styleMap.set(rootNode, component)
   const results = treeToSVG(rootNode, settings)
 
   fs.writeFileSync("jsx-render.svg", results)

--- a/src/ambient.d.ts
+++ b/src/ambient.d.ts
@@ -14,6 +14,8 @@ declare namespace jest {
 declare module "yoga-layout" {
 
   // https://github.com/facebook/yoga/blob/master/javascript/sources/YGEnums.js
+  // and https://github.com/facebook/yoga/blob/master/gentest/gentest-javascript.js
+
   const UNDEFINED: number
 
   const ALIGN_COUNT = 8
@@ -116,6 +118,16 @@ declare module "yoga-layout" {
   const JUSTIFY_FLEX_END = 2
   const JUSTIFY_SPACE_BETWEEN = 3
   const JUSTIFY_SPACE_AROUND = 4
+
+  /** Do not use this in your code */
+  enum Justify {
+    Count = 5,
+    FlexStart = 0,
+    Center = 1,
+    FlexEnd = 2,
+    SpaceBetween = 3,
+    SpaceAround = 3,
+  }
 
   const LOG_LEVEL_COUNT = 6
   const LOG_LEVEL_ERROR = 0
@@ -232,6 +244,8 @@ declare module "yoga-layout" {
 
     setFlex(ordinal: number)
     setFlexDirection(direct: FlexDirection)
+    setJustifyContent(justify: Justify)
+    setAlignItems(alignment: number)
 
     insertChild(node: NodeInstance, index: number)
     removeChild(node: NodeInstance)
@@ -263,3 +277,9 @@ declare module "yoga-layout" {
   // Globals
   function getInstanceCount(): number
 }
+
+// import {ViewStyle} from "react-native"
+
+// interface NodeInstance {
+//   style: ViewStyle
+// }

--- a/src/component-to-node.ts
+++ b/src/component-to-node.ts
@@ -29,23 +29,25 @@ const componentToNode = (component: Component, settings: Settings) => {
 
     if (style.flex) { node.setFlex(style.flex) }
 
-    if (!style.flexDirection) { node.setFlexDirection(yoga.FLEX_DIRECTION_ROW) }
     if (style.flexDirection === "row") { node.setFlexDirection(yoga.FLEX_DIRECTION_ROW) }
     if (style.flexDirection === "column") { node.setFlexDirection(yoga.FLEX_DIRECTION_COLUMN) }
     if (style.flexDirection === "row-reverse") { node.setFlexDirection(yoga.FLEX_DIRECTION_ROW_REVERSE) }
     if (style.flexDirection === "column-reverse") { node.setFlexDirection(yoga.FLEX_DIRECTION_COLUMN_REVERSE) }
 
-    // if (style.alignItems) {
-    //   let alignment: yoga.Align = 0
-    //   switch (style.alignItems) {
-    //     case "center":
-    //       alignment = yoga.ALIGN_CENTER
-    //       break
+    if (style.justifyContent === "flex-start") { node.setJustifyContent(yoga.JUSTIFY_FLEX_START) }
+    if (style.justifyContent === "flex-end") { node.setJustifyContent(yoga.JUSTIFY_FLEX_END) }
+    if (style.justifyContent === "center") { node.setJustifyContent(yoga.JUSTIFY_CENTER) }
+    if (style.justifyContent === "space-between") { node.setJustifyContent(yoga.JUSTIFY_SPACE_BETWEEN) }
+    if (style.justifyContent === "space-around") { node.setJustifyContent(yoga.JUSTIFY_SPACE_AROUND) }
 
-    //     default:
-    //       break
-    //   }
-    // }
+    if (style.alignItems === "flex-start") { node.setJustifyContent(yoga.ALIGN_FLEX_END) }
+    if (style.alignItems === "flex-end") { node.setJustifyContent(yoga.ALIGN_FLEX_END) }
+    if (style.alignItems === "center") { node.setJustifyContent(yoga.ALIGN_CENTER) }
+    if (style.alignItems === "stretch") { node.setJustifyContent(yoga.ALIGN_STRETCH) }
+    if (style.alignItems === "baseline") { node.setJustifyContent(yoga.ALIGN_BASELINE) }
+
+    node.myID = Math.random() * 50
+    console.log(` < (${node.myID})`, style)
   }
 
   return node

--- a/src/component-tree-to-nodes.ts
+++ b/src/component-tree-to-nodes.ts
@@ -4,10 +4,12 @@ import componentToNode from "./component-to-node"
 import { Component, Settings } from "./index"
 
 const treeToNodes = (root: Component, settings: Settings) => recurseTree(root, settings)
+
 export default treeToNodes
 
 export const recurseTree = (component: Component, settings: Settings) => {
   const node = componentToNode(component, settings)
+  settings.styleMap.set(node, component.props.style)
 
   if (component.children) {
     for (let index = 0; index < component.children.length; index++) {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,6 @@
+declare namespace jest {
+  interface Matchers {
+    /** Checks and sets up SVG rendering for React Components. */
+    toMatchSVGSnapshot(width: number, height: number): void;
+  }
+}

--- a/src/node-to-svg.ts
+++ b/src/node-to-svg.ts
@@ -1,15 +1,28 @@
+import {ViewStyle} from "react-native"
 import * as yoga from "yoga-layout"
+
 import { Settings } from "./index"
 import wsp from "./whitespace"
 
 const nodeToSVG = (indent: number, node: yoga.NodeInstance, settings: Settings) => {
   const layout = node.getComputedLayout()
-  const attributes = {
+  const attributes: any = {
     "fill-opacity": "0.1",
     "stroke-width": "1",
     "stroke": "black"
   }
 
+  const component = settings.styleMap.get(node)
+  if (component && component.props && component.props.style) {
+    const style = component.props.style
+    console.log("> ", component.props.style)
+    if (style.backgroundColor) {
+      attributes.fill = style.backgroundColor
+      attributes["fill-opacity"] = 1
+    }
+  } else {
+    console.log(` > (${node.myID})`, component)
+  }
   return "\n" + wsp(indent) + svgRect(layout.left, layout.top, layout.width, layout.height, attributes)
 }
 

--- a/src/tree-to-svg.ts
+++ b/src/tree-to-svg.ts
@@ -13,6 +13,7 @@ export const recurseTree =
 
     return nodeString + groupWrap(root, indent, () => {
       let childGroups = ""
+
       for (let index = 0; index < childrenCount; index++) {
         const child = root.getChild(index)
         childGroups += recurseTree(indent + 1, child, settings)

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,6 +10,16 @@
   version "7.0.18"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.18.tgz#cd67f27d3dc0cfb746f0bdd5e086c4c5d55be173"
 
+"@types/react-native@^0.44.3":
+  version "0.44.3"
+  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.44.3.tgz#675a999b1715fb0e4f7cf0917111c5df4a6c8056"
+  dependencies:
+    "@types/react" "*"
+
+"@types/react@*":
+  version "15.0.24"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-15.0.24.tgz#8a75299dc37906df327c18ca918bf97a55e7123b"
+
 abab@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.3.tgz#b81de5f7274ec4e756d797cd834f303642724e5d"


### PR DESCRIPTION
I'm a bit wary that in order to see the SVG, I need to click a button in the github PR. 

The format that we want should be image first in the PR or it'll not be useful, perhaps this cannot be an SVG, but would need to be a PDF? o.0

That said, I first expected a PNG, so maybe that's not too terrible - they compress well for chunks of consistent colour.

---

So I shipped a few releases to test in [Emission](https://github.com/artsy/emission/) which kinda worked, but found a lot of missing parts of the flex box spec. Not shocking. So I've taken some more examples and covered those. The align one is definitely wrong, the others aren't.