### PR TITLE
Handle re-applying styling from the compent at the SVG level

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+node_js: "node"
 
 cache:
   yarn: true

--- a/jsx-render.svg
+++ b/jsx-render.svg
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <svg width="600" height="400" xmlns="http://www.w3.org/2000/svg" version="1.1">
 
- <rect x="40" y="40" width="100" height="200" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+ <rect x="0" y="0" width="NaN" height="NaN" fill-opacity="0.1" stroke-width="1" stroke="black"/>
 
- <g transform='translate(40, 40)'>
-   <rect x="20" y="0" width="20" height="20" fill-opacity="0.1" stroke-width="1" stroke="black"/>
-   <rect x="20" y="40" width="160" height="40" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+ <g transform='translate(0, 0)'>
+   <rect x="0" y="0" width="NaN" height="NaN" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+   <rect x="0" y="0" width="NaN" height="NaN" fill-opacity="0.1" stroke-width="1" stroke="black"/>
 
-   <g transform='translate(20, 40)'>
-     <rect x="10" y="20" width="10" height="10" fill-opacity="0.1" stroke-width="1" stroke="black"/>
-     <rect x="20" y="40" width="10" height="10" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+   <g transform='translate(0, 0)'>
+     <rect x="0" y="0" width="NaN" height="NaN" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+     <rect x="0" y="0" width="NaN" height="NaN" fill-opacity="0.1" stroke-width="1" stroke="black"/>
    </g>
 
-   <rect x="20" y="80" width="20" height="20" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+   <rect x="0" y="0" width="NaN" height="NaN" fill-opacity="0.1" stroke-width="1" stroke="black"/>
  </g>
 
 </svg>

--- a/package.json
+++ b/package.json
@@ -57,8 +57,6 @@
     "preset": "react-native"
   },
   "dependencies": {
-    "@types/react-native": "^0.44.3",
-    "ts-lint": "^4.5.1",
     "yoga-layout": "^1.5.0"
   }
 }

--- a/src/_tests/__snapshots__/_node-instance-count.test.tsx.svg
+++ b/src/_tests/__snapshots__/_node-instance-count.test.tsx.svg
@@ -4,9 +4,9 @@
  <rect x="0" y="0" width="320" height="480" fill-opacity="0.1" stroke-width="1" stroke="black"/>
 
  <g transform='translate(0, 0)'>
-   <rect x="0" y="330" width="50" height="50" fill-opacity="0.1" stroke-width="1" stroke="black"/>
-   <rect x="0" y="380" width="50" height="50" fill-opacity="0.1" stroke-width="1" stroke="black"/>
-   <rect x="0" y="430" width="50" height="50" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+   <rect x="0" y="330" width="50" height="50" fill-opacity="1" stroke-width="1" stroke="black" fill="powderblue"/>
+   <rect x="0" y="380" width="50" height="50" fill-opacity="1" stroke-width="1" stroke="black" fill="skyblue"/>
+   <rect x="0" y="430" width="50" height="50" fill-opacity="1" stroke-width="1" stroke="black" fill="steelblue"/>
  </g>
 
 </svg>

--- a/src/_tests/__snapshots__/_node-to-svg.test.ts.snap
+++ b/src/_tests/__snapshots__/_node-to-svg.test.ts.snap
@@ -2,5 +2,5 @@
 
 exports[`nodeToSVG handles a simple square 1`] = `
 "
- <rect x=\\"0\\" y=\\"0\\" width=\\"NaN\\" height=\\"NaN\\" fill-opacity=\\"0.1\\" stroke-width=\\"1\\" stroke=\\"black\\"/>"
+ <rect x=\\"0\\" y=\\"0\\" width=\\"600\\" height=\\"400\\" fill-opacity=\\"0.1\\" stroke-width=\\"1\\" stroke=\\"black\\"/>"
 `;

--- a/src/_tests/__snapshots__/_tree-to-svg.test.ts.snap
+++ b/src/_tests/__snapshots__/_tree-to-svg.test.ts.snap
@@ -4,7 +4,7 @@ exports[`treeToSVG wraps whatever text you pass into it with an SVG schema 1`] =
 "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\" ?>
 <svg width=\\"1024\\" height=\\"768\\" xmlns=\\"http://www.w3.org/2000/svg\\" version=\\"1.1\\">
 
- <rect x=\\"20\\" y=\\"20\\" width=\\"600\\" height=\\"400\\" fill-opacity=\\"0.1\\" stroke-width=\\"1\\" stroke=\\"black\\"/>
+ <rect x=\\"2\\" y=\\"80\\" width=\\"200\\" height=\\"200\\" fill-opacity=\\"0.1\\" stroke-width=\\"1\\" stroke=\\"black\\"/>
 </svg>
 "
 `;

--- a/src/_tests/__snapshots__/render.test.tsx.snap
+++ b/src/_tests/__snapshots__/render.test.tsx.snap
@@ -4,18 +4,18 @@ exports[`handles some simple JSX 1`] = `
 "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\" ?>
 <svg width=\\"600\\" height=\\"400\\" xmlns=\\"http://www.w3.org/2000/svg\\" version=\\"1.1\\">
 
- <rect x=\\"40\\" y=\\"40\\" width=\\"100\\" height=\\"200\\" fill-opacity=\\"0.1\\" stroke-width=\\"1\\" stroke=\\"black\\"/>
+ <rect x=\\"0\\" y=\\"0\\" width=\\"NaN\\" height=\\"NaN\\" fill-opacity=\\"0.1\\" stroke-width=\\"1\\" stroke=\\"black\\"/>
 
- <g transform='translate(40, 40)'>
-   <rect x=\\"20\\" y=\\"0\\" width=\\"20\\" height=\\"20\\" fill-opacity=\\"0.1\\" stroke-width=\\"1\\" stroke=\\"black\\"/>
-   <rect x=\\"20\\" y=\\"40\\" width=\\"160\\" height=\\"40\\" fill-opacity=\\"0.1\\" stroke-width=\\"1\\" stroke=\\"black\\"/>
+ <g transform='translate(0, 0)'>
+   <rect x=\\"0\\" y=\\"0\\" width=\\"NaN\\" height=\\"NaN\\" fill-opacity=\\"0.1\\" stroke-width=\\"1\\" stroke=\\"black\\"/>
+   <rect x=\\"0\\" y=\\"0\\" width=\\"NaN\\" height=\\"NaN\\" fill-opacity=\\"0.1\\" stroke-width=\\"1\\" stroke=\\"black\\"/>
 
-   <g transform='translate(20, 40)'>
-     <rect x=\\"10\\" y=\\"20\\" width=\\"10\\" height=\\"10\\" fill-opacity=\\"0.1\\" stroke-width=\\"1\\" stroke=\\"black\\"/>
-     <rect x=\\"20\\" y=\\"40\\" width=\\"10\\" height=\\"10\\" fill-opacity=\\"0.1\\" stroke-width=\\"1\\" stroke=\\"black\\"/>
+   <g transform='translate(0, 0)'>
+     <rect x=\\"0\\" y=\\"0\\" width=\\"NaN\\" height=\\"NaN\\" fill-opacity=\\"0.1\\" stroke-width=\\"1\\" stroke=\\"black\\"/>
+     <rect x=\\"0\\" y=\\"0\\" width=\\"NaN\\" height=\\"NaN\\" fill-opacity=\\"0.1\\" stroke-width=\\"1\\" stroke=\\"black\\"/>
    </g>
 
-   <rect x=\\"20\\" y=\\"80\\" width=\\"20\\" height=\\"20\\" fill-opacity=\\"0.1\\" stroke-width=\\"1\\" stroke=\\"black\\"/>
+   <rect x=\\"0\\" y=\\"0\\" width=\\"NaN\\" height=\\"NaN\\" fill-opacity=\\"0.1\\" stroke-width=\\"1\\" stroke=\\"black\\"/>
  </g>
 
 </svg>

--- a/src/_tests/_node-to-svg.test.ts
+++ b/src/_tests/_node-to-svg.test.ts
@@ -2,23 +2,30 @@ import * as yoga from "yoga-layout"
 
 import nodeToSVG from "../node-to-svg"
 
+const component = (name) => ({
+  type: name,
+  props: {},
+  children: [],
+  layout: {
+    left: 0,
+    right: 6,
+    top: 0,
+    bottom: 100,
+    width: 600,
+    height: 400
+  }
+})
+
 describe("nodeToSVG", () => {
     it("handles a simple square", () => {
-      const rootNode = yoga.Node.create()
-      rootNode.setWidth(600)
-      rootNode.setHeight(400)
-      rootNode.setDisplay(yoga.DISPLAY_FLEX)
-      rootNode.setFlexDirection(yoga.FLEX_DIRECTION_ROW)
+      const rootNode = component("my component")
 
       const settings = {
         width: 1024,
         height: 768,
-        styleMap: new WeakMap()
       }
 
       const results = nodeToSVG(0, rootNode, settings)
       expect(results).toMatchSnapshot()
-
-      rootNode.free()
     })
 })

--- a/src/_tests/_tree-to-svg-sub-funcs.test.ts
+++ b/src/_tests/_tree-to-svg-sub-funcs.test.ts
@@ -2,6 +2,7 @@ const nodeToSVG = jest.fn()
 jest.mock("../node-to-svg.ts", () => ({ default: nodeToSVG }))
 
 import * as yoga from "yoga-layout"
+import { RenderedComponent } from "../index"
 import { recurseTree, svgWrapper } from "../tree-to-svg"
 
 describe("svgWrapper", () => {
@@ -10,8 +11,6 @@ describe("svgWrapper", () => {
       const settings = {
         width: 444,
         height: 555,
-                styleMap: new WeakMap()
-
       }
 
       const results = svgWrapper(body, settings)
@@ -19,50 +18,39 @@ describe("svgWrapper", () => {
     })
 })
 
+const component = (name) => ({
+  type: name,
+  props: {},
+  children: [],
+  layout: {
+    left: 2,
+    right: 6,
+    top: 80,
+    bottom: 100,
+    width: 200,
+    height: 200
+  }
+}) as RenderedComponent
+
 describe("recurseTree", () => {
     beforeEach(() => {
       nodeToSVG.mockReset()
     })
 
     it("Calls nodeToSVG for it's first node", () => {
-      const children = []
-      const fakeNode: any = {
-        getChild: (index) => children[index],
-        getChildCount: () => children.length,
-      }
+      const root = component("main")
+
       const settings = {
         width: 1024,
         height: 768,
-        styleMap: new WeakMap()
-
       }
-      const results = recurseTree(0, fakeNode, settings)
+      const results = recurseTree(0, root, settings)
       expect(nodeToSVG.mock.calls.length).toEqual(1)
     })
 
     it("Calls nodeToSVG for it's children nodes", () => {
-      const children = [] as any[]
-      const root: any = {
-        getChild: (index) => children[index],
-        getChildCount: () => children.length,
-        getComputedLeft: () => 20,
-        getComputedTop: () => 20,
-        id: "root"
-      }
-      const fakeNode2: any = {
-        getChild: (index) => null,
-        getChildCount: () => 0,
-        id: "2"
-      }
-
-      const fakeNode3: any = {
-        getChild: (index) => null,
-        getChildCount: () => 0,
-        id: "3"
-      }
-
-      children.push(fakeNode2)
-      children.push(fakeNode3)
+      const root = component("main")
+      root.children = [component("1"), component("2")]
 
       const settings = {
         width: 1024,

--- a/src/_tests/_tree-to-svg.test.ts
+++ b/src/_tests/_tree-to-svg.test.ts
@@ -3,23 +3,27 @@ import * as yoga from "yoga-layout"
 import treeToSVG from "../tree-to-svg"
 
 describe("treeToSVG", () => {
-    it("wraps whatever text you pass into it with an SVG schema", () => {
-      const rootNode = yoga.Node.create()
-      rootNode.setWidth(600)
-      rootNode.setHeight(400)
-      rootNode.setMargin(yoga.EDGE_ALL, 20)
-      rootNode.setDisplay(yoga.DISPLAY_FLEX)
-      rootNode.setFlexDirection(yoga.FLEX_DIRECTION_ROW)
-
-      const settings = {
-        width: 1024,
-        height: 768,
-        styleMap: new WeakMap()
+  it("wraps whatever text you pass into it with an SVG schema", () => {
+    const renderedComponent = {
+      type: "my component",
+      props: {},
+      children: [],
+      layout: {
+        left: 2,
+        right: 6,
+        top: 80,
+        bottom: 100,
+        width: 200,
+        height: 200
       }
+    }
 
-      const results = treeToSVG(rootNode, settings)
-      expect(results).toMatchSnapshot()
+    const settings = {
+      width: 1024,
+      height: 768,
+    }
 
-      rootNode.freeRecursive()
-    })
+    const results = treeToSVG(renderedComponent, settings)
+    expect(results).toMatchSnapshot()
+  })
 })

--- a/src/_tests/example_layouts/__snapshots__/_align-items.test.tsx.svg
+++ b/src/_tests/example_layouts/__snapshots__/_align-items.test.tsx.svg
@@ -4,9 +4,9 @@
  <rect x="0" y="0" width="320" height="480" fill-opacity="0.1" stroke-width="1" stroke="black"/>
 
  <g transform='translate(0, 0)'>
-   <rect x="0" y="330" width="50" height="50" fill-opacity="0.1" stroke-width="1" stroke="black"/>
-   <rect x="0" y="380" width="50" height="50" fill-opacity="0.1" stroke-width="1" stroke="black"/>
-   <rect x="0" y="430" width="50" height="50" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+   <rect x="0" y="330" width="50" height="50" fill-opacity="1" stroke-width="1" stroke="black" fill="powderblue"/>
+   <rect x="0" y="380" width="50" height="50" fill-opacity="1" stroke-width="1" stroke="black" fill="skyblue"/>
+   <rect x="0" y="430" width="50" height="50" fill-opacity="1" stroke-width="1" stroke="black" fill="steelblue"/>
  </g>
 
 </svg>

--- a/src/_tests/example_layouts/__snapshots__/_flex-direction.test.tsx.svg
+++ b/src/_tests/example_layouts/__snapshots__/_flex-direction.test.tsx.svg
@@ -4,9 +4,9 @@
  <rect x="0" y="0" width="320" height="480" fill-opacity="0.1" stroke-width="1" stroke="black"/>
 
  <g transform='translate(0, 0)'>
-   <rect x="0" y="0" width="50" height="50" fill-opacity="0.1" stroke-width="1" stroke="black"/>
-   <rect x="50" y="0" width="50" height="50" fill-opacity="0.1" stroke-width="1" stroke="black"/>
-   <rect x="100" y="0" width="50" height="50" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+   <rect x="0" y="0" width="50" height="50" fill-opacity="1" stroke-width="1" stroke="black" fill="powderblue"/>
+   <rect x="50" y="0" width="50" height="50" fill-opacity="1" stroke-width="1" stroke="black" fill="skyblue"/>
+   <rect x="100" y="0" width="50" height="50" fill-opacity="1" stroke-width="1" stroke="black" fill="steelblue"/>
  </g>
 
 </svg>

--- a/src/_tests/example_layouts/__snapshots__/_justify-contents.test.tsx.svg
+++ b/src/_tests/example_layouts/__snapshots__/_justify-contents.test.tsx.svg
@@ -4,9 +4,9 @@
  <rect x="0" y="0" width="320" height="480" fill-opacity="0.1" stroke-width="1" stroke="black"/>
 
  <g transform='translate(0, 0)'>
-   <rect x="0" y="0" width="50" height="50" fill-opacity="0.1" stroke-width="1" stroke="black"/>
-   <rect x="0" y="215" width="50" height="50" fill-opacity="0.1" stroke-width="1" stroke="black"/>
-   <rect x="0" y="430" width="50" height="50" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+   <rect x="0" y="0" width="50" height="50" fill-opacity="1" stroke-width="1" stroke="black" fill="powderblue"/>
+   <rect x="0" y="215" width="50" height="50" fill-opacity="1" stroke-width="1" stroke="black" fill="skyblue"/>
+   <rect x="0" y="430" width="50" height="50" fill-opacity="1" stroke-width="1" stroke="black" fill="steelblue"/>
  </g>
 
 </svg>

--- a/src/_tests/example_layouts/_align-items.test.tsx
+++ b/src/_tests/example_layouts/_align-items.test.tsx
@@ -6,7 +6,7 @@ import * as renderer from "react-test-renderer"
 
 // https://facebook.github.io/react-native/docs/flexbox.html
 
-it("Renders three vertically/horizonyally centeredblocks", () => {
+it("Renders three vertically/horizontally centeredblocks", () => {
   const jsx =
       <View style={{
         flex: 1,

--- a/src/_tests/render.test.tsx
+++ b/src/_tests/render.test.tsx
@@ -5,6 +5,7 @@ import { View } from "react-native"
 import * as renderer from "react-test-renderer"
 
 import componentTreeToNodeTree from "../component-tree-to-nodes"
+import renderedComponentTree from "../reapply-layouts-to-components"
 import treeToSVG from "../tree-to-svg"
 
 import * as fs from "fs"
@@ -26,12 +27,11 @@ it("handles some simple JSX", () => {
   const settings = {
     width:  600,
     height: 400,
-    styleMap: new WeakMap()
   }
 
   const rootNode = componentTreeToNodeTree(component, settings)
-  settings.styleMap.set(rootNode, component)
-  const results = treeToSVG(rootNode, settings)
+  const rendered = renderedComponentTree(component, rootNode)
+  const results = treeToSVG(rendered, settings)
 
   fs.writeFileSync("jsx-render.svg", results)
   expect(results).toMatchSnapshot()

--- a/src/ambient.d.ts
+++ b/src/ambient.d.ts
@@ -14,7 +14,7 @@ declare namespace jest {
 declare module "yoga-layout" {
 
   // https://github.com/facebook/yoga/blob/master/javascript/sources/YGEnums.js
-  // and https://github.com/facebook/yoga/blob/master/gentest/gentest-javascript.js
+  // and https://github.com/facebook/yoga/blob/master/gentest/gentest-javascript.js 5
 
   const UNDEFINED: number
 
@@ -250,9 +250,11 @@ declare module "yoga-layout" {
     insertChild(node: NodeInstance, index: number)
     removeChild(node: NodeInstance)
 
-    getComputedWidth(): number
     getComputedLeft(): number
+    getComputedRight(): number
     getComputedTop(): number
+    getComputedBottom(): number
+    getComputedWidth(): number
     getComputedHeight(): number
 
     getChild(index: number): NodeInstance

--- a/src/component-to-node.ts
+++ b/src/component-to-node.ts
@@ -45,9 +45,6 @@ const componentToNode = (component: Component, settings: Settings) => {
     if (style.alignItems === "center") { node.setJustifyContent(yoga.ALIGN_CENTER) }
     if (style.alignItems === "stretch") { node.setJustifyContent(yoga.ALIGN_STRETCH) }
     if (style.alignItems === "baseline") { node.setJustifyContent(yoga.ALIGN_BASELINE) }
-
-    node.myID = Math.random() * 50
-    console.log(` < (${node.myID})`, style)
   }
 
   return node

--- a/src/component-tree-to-nodes.ts
+++ b/src/component-tree-to-nodes.ts
@@ -9,7 +9,6 @@ export default treeToNodes
 
 export const recurseTree = (component: Component, settings: Settings) => {
   const node = componentToNode(component, settings)
-  settings.styleMap.set(node, component.props.style)
 
   if (component.children) {
     for (let index = 0; index < component.children.length; index++) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,6 @@ export interface RenderedComponent {
 export interface Settings {
     width: number
     height: number
-    styleMap: Map<yoga.NodeInstance, Component>
 }
 
 import componentTreeToNodeTree from "./component-tree-to-nodes"
@@ -56,7 +55,7 @@ expect.extend({
         // We will need to do something smarter in the future, these snapshots need to be 1 file per test
         // whereas jest-snapshots can be multi-test per file.
 
-        const settings: Settings = { width, height, styleMap: new Map() }
+        const settings: Settings = { width, height }
         const rootNode = componentTreeToNodeTree(root, settings)
         // This will mutate the node tree, we cannot trust that the nodes  in the original tree will
         // still exist.

--- a/src/node-to-svg.ts
+++ b/src/node-to-svg.ts
@@ -1,27 +1,23 @@
 import {ViewStyle} from "react-native"
 import * as yoga from "yoga-layout"
 
-import { Settings } from "./index"
+import { RenderedComponent, Settings } from "./index"
 import wsp from "./whitespace"
 
-const nodeToSVG = (indent: number, node: yoga.NodeInstance, settings: Settings) => {
-  const layout = node.getComputedLayout()
+const nodeToSVG = (indent: number, node: RenderedComponent, settings: Settings) => {
+  const layout = node.layout
   const attributes: any = {
     "fill-opacity": "0.1",
     "stroke-width": "1",
     "stroke": "black"
   }
 
-  const component = settings.styleMap.get(node)
-  if (component && component.props && component.props.style) {
-    const style = component.props.style
-    console.log("> ", component.props.style)
+  if (node && node.props && node.props.style) {
+    const style = node.props.style
     if (style.backgroundColor) {
       attributes.fill = style.backgroundColor
       attributes["fill-opacity"] = 1
     }
-  } else {
-    console.log(` > (${node.myID})`, component)
   }
   return "\n" + wsp(indent) + svgRect(layout.left, layout.top, layout.width, layout.height, attributes)
 }

--- a/src/reapply-layouts-to-components.ts
+++ b/src/reapply-layouts-to-components.ts
@@ -1,0 +1,35 @@
+import {ViewStyle} from "react-native"
+import * as yoga from "yoga-layout"
+
+import { Component, RenderedComponent } from "./index"
+
+const renderedComponentTree = (root: Component, node: yoga.NodeInstance) => recurseTree(root, node)
+
+export default renderedComponentTree
+
+export const recurseTree = (component: Component, node: yoga.NodeInstance) => {
+
+  const newChildren = [] as RenderedComponent[]
+  if (component.children) {
+    for (let index = 0; index < component.children.length; index++) {
+      const childComponent = component.children[index]
+      const childNode = node.getChild(index)
+      const renderedChildComponent = recurseTree(childComponent, childNode)
+      newChildren.push(renderedChildComponent)
+    }
+  }
+
+  return {
+    type: component.type,
+    props: component.props,
+    children: newChildren,
+    layout : {
+      left: node.getComputedLeft(),
+      right: node.getComputedRight(),
+      top: node.getComputedTop(),
+      bottom: node.getComputedBottom(),
+      width: node.getComputedWidth(),
+      height: node.getComputedHeight()
+    }
+  } as RenderedComponent
+}

--- a/src/tree-to-svg.ts
+++ b/src/tree-to-svg.ts
@@ -1,21 +1,21 @@
 import * as yoga from "yoga-layout"
-import { Settings } from "./index"
+import { RenderedComponent, Settings } from "./index"
 import nodeToSVG from "./node-to-svg"
 import wsp from "./whitespace"
 
 export const recurseTree =
-  (indent: number, root: yoga.NodeInstance, settings: Settings) => {
+  (indent: number, root: RenderedComponent, settings: Settings) => {
 
     const nodeString = nodeToSVG(indent, root, settings)
 
-    const childrenCount = root.getChildCount()
+    const childrenCount = root.children.length
     if (!childrenCount) { return nodeString }
 
     return nodeString + groupWrap(root, indent, () => {
       let childGroups = ""
 
       for (let index = 0; index < childrenCount; index++) {
-        const child = root.getChild(index)
+        const child = root.children[index]
         childGroups += recurseTree(indent + 1, child, settings)
       }
 
@@ -30,14 +30,13 @@ ${bodyText}
 </svg>
 `
 
-export const groupWrap = (node: yoga.NodeInstance, indent: number, recurse: () => string) => `
+export const groupWrap = (node: RenderedComponent, indent: number, recurse: () => string) => `
 
-${wsp(indent)}<g transform='translate(${node.getComputedLeft()}, ${node.getComputedTop()})'>${recurse()}
+${wsp(indent)}<g transform='translate(${node.layout.left}, ${node.layout.top})'>${recurse()}
 ${wsp(indent)}</g>
 `
 
-const treeToSVG = (root: yoga.NodeInstance, settings: Settings) => {
-  root.calculateLayout(settings.width, settings.height, yoga.DIRECTION_LTR)
+const treeToSVG = (root: RenderedComponent, settings: Settings) => {
   return svgWrapper(recurseTree(0, root, settings), settings)
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,16 +10,6 @@
   version "7.0.18"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.18.tgz#cd67f27d3dc0cfb746f0bdd5e086c4c5d55be173"
 
-"@types/react-native@^0.44.3":
-  version "0.44.3"
-  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.44.3.tgz#675a999b1715fb0e4f7cf0917111c5df4a6c8056"
-  dependencies:
-    "@types/react" "*"
-
-"@types/react@*":
-  version "15.0.24"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-15.0.24.tgz#8a75299dc37906df327c18ca918bf97a55e7123b"
-
 abab@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.3.tgz#b81de5f7274ec4e756d797cd834f303642724e5d"
@@ -259,7 +249,7 @@ babel-cli@^6.24.1:
   optionalDependencies:
     chokidar "^1.6.1"
 
-babel-code-frame@^6.20.0, babel-code-frame@^6.22.0:
+babel-code-frame@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.22.0.tgz#027620bee567a88c32561574e7fd0801d33118e4"
   dependencies:
@@ -1446,7 +1436,7 @@ detect-indent@^4.0.0:
   dependencies:
     repeating "^2.0.0"
 
-diff@^3.0.0, diff@^3.0.1, diff@^3.1.0, diff@^3.2.0:
+diff@^3.0.0, diff@^3.1.0, diff@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
 
@@ -4079,7 +4069,7 @@ resolve@1.1.7, resolve@~1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-resolve@^1.1.7, resolve@^1.2.0, resolve@^1.3.2:
+resolve@^1.2.0, resolve@^1.3.2:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.3.tgz#655907c3469a8680dc2de3a275a8fdd69691f0e5"
   dependencies:
@@ -4575,19 +4565,6 @@ ts-jest@^20.0.0:
     tsconfig "^6.0.0"
     yargs "^8.0.1"
 
-ts-lint@^4.5.1:
-  version "4.5.1"
-  resolved "https://registry.yarnpkg.com/ts-lint/-/ts-lint-4.5.1.tgz#9c22b7b7b862b67324dd1bd213a845c03a7fb8c0"
-  dependencies:
-    babel-code-frame "^6.20.0"
-    colors "^1.1.2"
-    diff "^3.0.1"
-    findup-sync "~0.3.0"
-    glob "^7.1.1"
-    optimist "~0.6.0"
-    resolve "^1.1.7"
-    tsutils "^1.1.0"
-
 ts-node@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-3.0.4.tgz#a1475ebf24fd4e2ee2fba8b1aa1605b977bde506"
@@ -4633,7 +4610,7 @@ tsscmp@1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/tsscmp/-/tsscmp-1.0.5.tgz#7dc4a33af71581ab4337da91d85ca5427ebd9a97"
 
-tsutils@^1.1.0, tsutils@^1.8.0:
+tsutils@^1.8.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-1.9.1.tgz#b9f9ab44e55af9681831d5f28d0aeeaf5c750cb0"
 


### PR DESCRIPTION
~~WIP - Tests are definitely broken, but this proved my concept well 👍 will need to adjust tests to not take Yoga nodes, so they're failing.~~

![screen shot 2017-05-21 at 13 26 37](https://cloud.githubusercontent.com/assets/49038/26283968/26392d96-3e29-11e7-9d47-752e41d0013b.png)

In https://github.com/orta/jest-snapshots-svg/pull/7 I continued the process of:

> React Renderer -> Components as JSON -> Yoga Nodes -> SVG

This worked until I needed some of the Components style to do work at the SVG generation. My attempt in #7 was to create a map of node -> style object from a component. This didn't work, and it took me a while to figure it. I assume that Yoga uses immutable data objects, so when we trigger a layout (after just before starting SVG parsing) the Yoga Tree is effectively replaced at runtime by new (immutable also) objects, so lookup always failed.

So this PR introduces:

> React Renderer -> Components as JSON -> Yoga Nodes -> RenderedComponents -> SVG

So the Layout pass happen just after we've got all Yoga nodes sorted, then in the creation of a RenderedComponent the values are copied out ( and the yoga nodes can be de-referenced from memory then) - these rendered components are then the things that are turned into SVG. Giving us access to the original style objects - meaning we can change the background colour.
