### PR TITLE
Render text ish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-snapshots-svg",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Generate SVG Snapshots of React Native Component Trees",
   "main": "build/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-snapshots-svg",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Generate SVG Snapshots of React Native Component Trees",
   "main": "build/index.js",
   "files": [

--- a/src/_tests/example_layouts/__snapshots__/_text.test.tsx.svg
+++ b/src/_tests/example_layouts/__snapshots__/_text.test.tsx.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<svg width="320" height="480" xmlns="http://www.w3.org/2000/svg" version="1.1">
+
+ <rect x="0" y="0" width="320" height="480" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+
+ <g transform='translate(0, 0)'>
+   <rect x="110" y="227" width="100" height="32" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+
+   <g transform='translate(110, 227)'>
+     <rect x="0" y="0" width="100" height="0" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+   </g>
+
+ </g>
+
+</svg>

--- a/src/_tests/example_layouts/_text.test.tsx
+++ b/src/_tests/example_layouts/_text.test.tsx
@@ -1,0 +1,25 @@
+import "../../index"
+
+import * as React from "react"
+import { Text, View } from "react-native"
+import * as renderer from "react-test-renderer"
+
+it("Renders three vertically/horizontally centeredblocks", () => {
+  const jsx =
+    <View style={{
+      flex: 1,
+      flexDirection: "column",
+      justifyContent: "center",
+      alignItems: "center",
+    }}>
+      <Text style={{
+        width: 100,
+        fontFamily: "AGaramondPro-Regular",
+        fontSize: 16,
+        marginTop: 5,
+      }}>Hello there, here are some words</Text>
+    </View>
+
+  const component = renderer.create(jsx).toJSON()
+  expect(component).toMatchSVGSnapshot(320, 480)
+})

--- a/src/component-to-node.ts
+++ b/src/component-to-node.ts
@@ -16,6 +16,11 @@ const componentToNode = (component: Component, settings: Settings) => {
     if (style.width) { node.setWidth(style.width) }
     if (style.height) { node.setHeight(style.height) }
 
+    // Potentially temporary, but should at least provide some layout stubbing
+    // See https://github.com/orta/jest-snapshots-svg/issues/11 for a bit more context
+    //
+    if (!style.height && style.fontSize) { node.setHeight(style.fontSize * 2) }
+
     if (style.marginTop) { node.setMargin(yoga.EDGE_TOP, style.marginTop) }
     if (style.marginBottom) { node.setMargin(yoga.EDGE_BOTTOM, style.marginBottom) }
     if (style.marginLeft) { node.setMargin(yoga.EDGE_LEFT, style.marginLeft) }


### PR DESCRIPTION
Handles faking the text by using the font size to estimate the height for a component. Obviously not good enough for the long term, but can do for now.