### PR TITLE
Guestimate text width

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,10 +1,10 @@
 src
 build/_tests
+build/src
 .vscode
 .babelrc
 .travis.yml
 dangerfile.ts
-jsx-render.svg
 tsconfig.json
 tslint.json
 yarn.lock

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,8 @@
     "**/.jest": true,
     "**/node_modules": true,
     "**/build": true
-  }
+  },
+  "prettier.semi": false,
+  "prettier.printWidth": 120,
+  "prettier.singleQuote": false
 }

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2017  <> and Artsy Inc. <engineering@artsymail.com>
+Copyright (c) 2017  <orta.therox@gmail.com> and Artsy Inc. <engineering@artsymail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/jsx-render.svg
+++ b/jsx-render.svg
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <svg width="600" height="400" xmlns="http://www.w3.org/2000/svg" version="1.1">
 
- <rect x="0" y="0" width="NaN" height="NaN" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+ <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="NaN" height="NaN"/>
 
  <g transform='translate(0, 0)'>
-   <rect x="0" y="0" width="NaN" height="NaN" fill-opacity="0.1" stroke-width="1" stroke="black"/>
-   <rect x="0" y="0" width="NaN" height="NaN" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+   <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="NaN" height="NaN"/>
+   <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="NaN" height="NaN"/>
 
    <g transform='translate(0, 0)'>
-     <rect x="0" y="0" width="NaN" height="NaN" fill-opacity="0.1" stroke-width="1" stroke="black"/>
-     <rect x="0" y="0" width="NaN" height="NaN" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+     <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="NaN" height="NaN"/>
+     <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="NaN" height="NaN"/>
    </g>
 
-   <rect x="0" y="0" width="NaN" height="NaN" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+   <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="NaN" height="NaN"/>
  </g>
 
 </svg>

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "files": [
     "build/*"
   ],
-  "typings": "build/index.d.ts",
+  "typings": "build/external-api.d.ts",
   "author": "Orta Therox <orta.therox@gmail.com> & Art.sy Inc",
   "license": "MIT",
   "devDependencies": {
@@ -32,7 +32,7 @@
     "lint": "tslint 'src/**/*.{ts,tsx}'",
     "precommit": "lint-staged",
     "prepush": "yarn build && yarn jest",
-    "prepublish": "cp src/external-api.d.ts build/index.d.ts"
+    "prepublish": "cp src/external-api.d.ts build"
   },
   "lint-staged": {
     "*.@(ts|tsx)": [

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lint": "tslint 'src/**/*.{ts,tsx}'",
     "precommit": "lint-staged",
     "prepush": "yarn build && yarn jest",
-    "prepublish": "cp src/external-api.d.ts build"
+    "prepublishOnly": "yarn build && cp src/external-api.d.ts build"
   },
   "lint-staged": {
     "*.@(ts|tsx)": [

--- a/package.json
+++ b/package.json
@@ -28,11 +28,10 @@
   },
   "scripts": {
     "type-check": "tsc --noEmit",
-    "build": "tsc",
+    "build": "tsc && cp src/external-api.d.ts build",
     "lint": "tslint 'src/**/*.{ts,tsx}'",
     "precommit": "lint-staged",
-    "prepush": "yarn build && yarn jest",
-    "prepublishOnly": "yarn build && cp src/external-api.d.ts build"
+    "prepush": "yarn build && yarn jest"
   },
   "lint-staged": {
     "*.@(ts|tsx)": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-snapshots-svg",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Generate SVG Snapshots of React Native Component Trees",
   "main": "build/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-snapshots-svg",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Generate SVG Snapshots of React Native Component Trees",
   "main": "build/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-snapshots-svg",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Generate SVG Snapshots of React Native Component Trees",
   "main": "build/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-snapshots-svg",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Generate SVG Snapshots of React Native Component Trees",
   "main": "build/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-snapshots-svg",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "Generate SVG Snapshots of React Native Component Trees",
   "main": "build/index.js",
   "files": [
@@ -11,6 +11,7 @@
   "license": "MIT",
   "devDependencies": {
     "@types/jest": "^19.2.3",
+    "@types/node": "^7.0.31",
     "babel-cli": "^6.24.1",
     "babel-jest": "^20.0.3",
     "danger": "^0.18.0",
@@ -59,7 +60,6 @@
     "preset": "react-native"
   },
   "dependencies": {
-    "@types/node": "^7.0.31",
     "nbind": "^0.3.12",
     "yoga-layout": "^1.5.0"
   }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "scripts": {
     "type-check": "tsc --noEmit",
     "build": "tsc && cp src/external-api.d.ts build",
+    "watch": "tsc --watch",
     "lint": "tslint 'src/**/*.{ts,tsx}'",
     "precommit": "lint-staged",
     "prepush": "yarn build && yarn jest"
@@ -58,6 +59,7 @@
     "preset": "react-native"
   },
   "dependencies": {
+    "@types/node": "^7.0.31",
     "nbind": "^0.3.12",
     "yoga-layout": "^1.5.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-snapshots-svg",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Generate SVG Snapshots of React Native Component Trees",
   "main": "build/index.js",
   "files": [

--- a/src/_tests/__snapshots__/_component-to-node.test.ts.snap
+++ b/src/_tests/__snapshots__/_component-to-node.test.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`styleFromComponent handles deeply nested arrays of styles 1`] = `[Function]`;

--- a/src/_tests/__snapshots__/_node-instance-count.test.tsx.svg
+++ b/src/_tests/__snapshots__/_node-instance-count.test.tsx.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <svg width="320" height="480" xmlns="http://www.w3.org/2000/svg" version="1.1">
 
- <rect x="0" y="0" width="320" height="480" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+ <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="320" height="480"/>
 
  <g transform='translate(0, 0)'>
-   <rect x="135" y="165" width="50" height="50" fill-opacity="1" stroke-width="1" stroke="black" fill="powderblue"/>
-   <rect x="135" y="215" width="50" height="50" fill-opacity="1" stroke-width="1" stroke="black" fill="skyblue"/>
-   <rect x="135" y="265" width="50" height="50" fill-opacity="1" stroke-width="1" stroke="black" fill="steelblue"/>
+   <rect type="View" fill-opacity="1" stroke-width="1" stroke="black" fill="powderblue" x="135" y="165" width="50" height="50"/>
+   <rect type="View" fill-opacity="1" stroke-width="1" stroke="black" fill="skyblue" x="135" y="215" width="50" height="50"/>
+   <rect type="View" fill-opacity="1" stroke-width="1" stroke="black" fill="steelblue" x="135" y="265" width="50" height="50"/>
  </g>
 
 </svg>

--- a/src/_tests/__snapshots__/_node-to-svg.test.ts.snap
+++ b/src/_tests/__snapshots__/_node-to-svg.test.ts.snap
@@ -2,5 +2,5 @@
 
 exports[`nodeToSVG handles a simple square 1`] = `
 "
- <rect x=\\"0\\" y=\\"0\\" width=\\"600\\" height=\\"400\\" fill-opacity=\\"0.1\\" stroke-width=\\"1\\" stroke=\\"black\\"/>"
+ <rect type=\\"my component\\" fill-opacity=\\"0.1\\" stroke-width=\\"1\\" stroke=\\"black\\" x=\\"0\\" y=\\"0\\" width=\\"600\\" height=\\"400\\"/>"
 `;

--- a/src/_tests/__snapshots__/_tree-to-svg.test.ts.snap
+++ b/src/_tests/__snapshots__/_tree-to-svg.test.ts.snap
@@ -4,7 +4,7 @@ exports[`treeToSVG wraps whatever text you pass into it with an SVG schema 1`] =
 "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\" ?>
 <svg width=\\"1024\\" height=\\"768\\" xmlns=\\"http://www.w3.org/2000/svg\\" version=\\"1.1\\">
 
- <rect x=\\"2\\" y=\\"80\\" width=\\"200\\" height=\\"200\\" fill-opacity=\\"0.1\\" stroke-width=\\"1\\" stroke=\\"black\\"/>
+ <rect type=\\"my component\\" fill-opacity=\\"0.1\\" stroke-width=\\"1\\" stroke=\\"black\\" x=\\"2\\" y=\\"80\\" width=\\"200\\" height=\\"200\\"/>
 </svg>
 "
 `;

--- a/src/_tests/__snapshots__/render.test.tsx.snap
+++ b/src/_tests/__snapshots__/render.test.tsx.snap
@@ -4,18 +4,18 @@ exports[`handles some simple JSX 1`] = `
 "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\" ?>
 <svg width=\\"600\\" height=\\"400\\" xmlns=\\"http://www.w3.org/2000/svg\\" version=\\"1.1\\">
 
- <rect x=\\"0\\" y=\\"0\\" width=\\"NaN\\" height=\\"NaN\\" fill-opacity=\\"0.1\\" stroke-width=\\"1\\" stroke=\\"black\\"/>
+ <rect type=\\"View\\" fill-opacity=\\"0.1\\" stroke-width=\\"1\\" stroke=\\"black\\" x=\\"0\\" y=\\"0\\" width=\\"NaN\\" height=\\"NaN\\"/>
 
  <g transform='translate(0, 0)'>
-   <rect x=\\"0\\" y=\\"0\\" width=\\"NaN\\" height=\\"NaN\\" fill-opacity=\\"0.1\\" stroke-width=\\"1\\" stroke=\\"black\\"/>
-   <rect x=\\"0\\" y=\\"0\\" width=\\"NaN\\" height=\\"NaN\\" fill-opacity=\\"0.1\\" stroke-width=\\"1\\" stroke=\\"black\\"/>
+   <rect type=\\"View\\" fill-opacity=\\"0.1\\" stroke-width=\\"1\\" stroke=\\"black\\" x=\\"0\\" y=\\"0\\" width=\\"NaN\\" height=\\"NaN\\"/>
+   <rect type=\\"View\\" fill-opacity=\\"0.1\\" stroke-width=\\"1\\" stroke=\\"black\\" x=\\"0\\" y=\\"0\\" width=\\"NaN\\" height=\\"NaN\\"/>
 
    <g transform='translate(0, 0)'>
-     <rect x=\\"0\\" y=\\"0\\" width=\\"NaN\\" height=\\"NaN\\" fill-opacity=\\"0.1\\" stroke-width=\\"1\\" stroke=\\"black\\"/>
-     <rect x=\\"0\\" y=\\"0\\" width=\\"NaN\\" height=\\"NaN\\" fill-opacity=\\"0.1\\" stroke-width=\\"1\\" stroke=\\"black\\"/>
+     <rect type=\\"View\\" fill-opacity=\\"0.1\\" stroke-width=\\"1\\" stroke=\\"black\\" x=\\"0\\" y=\\"0\\" width=\\"NaN\\" height=\\"NaN\\"/>
+     <rect type=\\"View\\" fill-opacity=\\"0.1\\" stroke-width=\\"1\\" stroke=\\"black\\" x=\\"0\\" y=\\"0\\" width=\\"NaN\\" height=\\"NaN\\"/>
    </g>
 
-   <rect x=\\"0\\" y=\\"0\\" width=\\"NaN\\" height=\\"NaN\\" fill-opacity=\\"0.1\\" stroke-width=\\"1\\" stroke=\\"black\\"/>
+   <rect type=\\"View\\" fill-opacity=\\"0.1\\" stroke-width=\\"1\\" stroke=\\"black\\" x=\\"0\\" y=\\"0\\" width=\\"NaN\\" height=\\"NaN\\"/>
  </g>
 
 </svg>

--- a/src/_tests/__snapshots__/render.test.tsx.svg
+++ b/src/_tests/__snapshots__/render.test.tsx.svg
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <svg width="1024" height="768" xmlns="http://www.w3.org/2000/svg" version="1.1">
 
- <rect x="40" y="40" width="100" height="200" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+ <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="40" y="40" width="100" height="200"/>
 
  <g transform='translate(40, 40)'>
-   <rect x="20" y="0" width="20" height="20" fill-opacity="0.1" stroke-width="1" stroke="black"/>
-   <rect x="20" y="40" width="160" height="40" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+   <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="20" y="0" width="20" height="20"/>
+   <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="20" y="40" width="160" height="40"/>
 
    <g transform='translate(20, 40)'>
-     <rect x="10" y="20" width="10" height="10" fill-opacity="0.1" stroke-width="1" stroke="black"/>
-     <rect x="20" y="40" width="10" height="10" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+     <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="10" y="20" width="10" height="10"/>
+     <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="20" y="40" width="10" height="10"/>
    </g>
 
-   <rect x="20" y="80" width="20" height="20" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+   <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="20" y="80" width="20" height="20"/>
  </g>
 
 </svg>

--- a/src/_tests/_component-to-node.test.ts
+++ b/src/_tests/_component-to-node.test.ts
@@ -1,31 +1,61 @@
 import * as yoga from "yoga-layout"
 
-import componentToNode from "../component-to-node"
+import componentToNode, { styleFromComponent } from "../component-to-node"
 
 describe("componentToNode", () => {
-    it("generates the width for a simple component", () => {
-      const component = {
-        type: "View",
-        props: {
-          style: {
-            width: 300,
-            height: 40
-          }
+  it("generates the width for a simple component", () => {
+    const component = {
+      type: "View",
+      props: {
+        style: {
+          width: 300,
+          height: 40
+        }
+      },
+      children: null
+    }
+
+    const settings = {
+      width: 1024,
+      height: 768
+    }
+
+    const node = componentToNode(component, settings)
+    node.calculateLayout(yoga.UNDEFINED, yoga.UNDEFINED, yoga.DIRECTION_INHERIT)
+
+    expect(node.getComputedWidth()).toEqual(300)
+    expect(node.getComputedHeight()).toEqual(40)
+
+    node.free()
+  })
+})
+
+const componentWithStyle = (style: any) => ({ kind: "Stub", props: {style}})
+
+describe("styleFromComponent", () => {
+  it("handles deeply nested arrays of styles", () => {
+    const style = [
+      {
+        fontSize: 30,
+        color: "black",
+        textAlign: "left",
+        paddingLeft: 20,
+        paddingRight: 20
+      },
+      [
+        {
+          textAlign: "center",
+          fontSize: 30,
+          lineHeight: 32,
+          width: 280,
+          marginTop: 35,
+          alignSelf: "center"
         },
-        children: null
-      }
-
-      const settings = {
-        width: 1024,
-        height: 768,
-      }
-
-      const node = componentToNode(component, settings)
-      node.calculateLayout(yoga.UNDEFINED, yoga.UNDEFINED, yoga.DIRECTION_INHERIT)
-
-      expect(node.getComputedWidth()).toEqual(300)
-      expect(node.getComputedHeight()).toEqual(40)
-
-      node.free()
-    })
+        null
+      ],
+      { fontFamily: "AGaramondPro-Regular" }
+    ]
+    const component = componentWithStyle(style)
+    expect(styleFromComponent).toMatchSnapshot()
+  })
 })

--- a/src/_tests/example_layouts/__snapshots__/_align-items.test.tsx.svg
+++ b/src/_tests/example_layouts/__snapshots__/_align-items.test.tsx.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <svg width="320" height="480" xmlns="http://www.w3.org/2000/svg" version="1.1">
 
- <rect x="0" y="0" width="320" height="480" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+ <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="320" height="480"/>
 
  <g transform='translate(0, 0)'>
-   <rect x="135" y="165" width="50" height="50" fill-opacity="1" stroke-width="1" stroke="black" fill="powderblue"/>
-   <rect x="135" y="215" width="50" height="50" fill-opacity="1" stroke-width="1" stroke="black" fill="skyblue"/>
-   <rect x="135" y="265" width="50" height="50" fill-opacity="1" stroke-width="1" stroke="black" fill="steelblue"/>
+   <rect type="View" fill-opacity="1" stroke-width="1" stroke="black" fill="powderblue" x="135" y="165" width="50" height="50"/>
+   <rect type="View" fill-opacity="1" stroke-width="1" stroke="black" fill="skyblue" x="135" y="215" width="50" height="50"/>
+   <rect type="View" fill-opacity="1" stroke-width="1" stroke="black" fill="steelblue" x="135" y="265" width="50" height="50"/>
  </g>
 
 </svg>

--- a/src/_tests/example_layouts/__snapshots__/_flex-direction.test.tsx.svg
+++ b/src/_tests/example_layouts/__snapshots__/_flex-direction.test.tsx.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <svg width="320" height="480" xmlns="http://www.w3.org/2000/svg" version="1.1">
 
- <rect x="0" y="0" width="320" height="480" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+ <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="320" height="480"/>
 
  <g transform='translate(0, 0)'>
-   <rect x="0" y="0" width="50" height="50" fill-opacity="1" stroke-width="1" stroke="black" fill="powderblue"/>
-   <rect x="50" y="0" width="50" height="50" fill-opacity="1" stroke-width="1" stroke="black" fill="skyblue"/>
-   <rect x="100" y="0" width="50" height="50" fill-opacity="1" stroke-width="1" stroke="black" fill="steelblue"/>
+   <rect type="View" fill-opacity="1" stroke-width="1" stroke="black" fill="powderblue" x="0" y="0" width="50" height="50"/>
+   <rect type="View" fill-opacity="1" stroke-width="1" stroke="black" fill="skyblue" x="50" y="0" width="50" height="50"/>
+   <rect type="View" fill-opacity="1" stroke-width="1" stroke="black" fill="steelblue" x="100" y="0" width="50" height="50"/>
  </g>
 
 </svg>

--- a/src/_tests/example_layouts/__snapshots__/_justify-contents.test.tsx.svg
+++ b/src/_tests/example_layouts/__snapshots__/_justify-contents.test.tsx.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <svg width="320" height="480" xmlns="http://www.w3.org/2000/svg" version="1.1">
 
- <rect x="0" y="0" width="320" height="480" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+ <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="320" height="480"/>
 
  <g transform='translate(0, 0)'>
-   <rect x="0" y="0" width="50" height="50" fill-opacity="1" stroke-width="1" stroke="black" fill="powderblue"/>
-   <rect x="0" y="215" width="50" height="50" fill-opacity="1" stroke-width="1" stroke="black" fill="skyblue"/>
-   <rect x="0" y="430" width="50" height="50" fill-opacity="1" stroke-width="1" stroke="black" fill="steelblue"/>
+   <rect type="View" fill-opacity="1" stroke-width="1" stroke="black" fill="powderblue" x="0" y="0" width="50" height="50"/>
+   <rect type="View" fill-opacity="1" stroke-width="1" stroke="black" fill="skyblue" x="0" y="215" width="50" height="50"/>
+   <rect type="View" fill-opacity="1" stroke-width="1" stroke="black" fill="steelblue" x="0" y="430" width="50" height="50"/>
  </g>
 
 </svg>

--- a/src/_tests/example_layouts/__snapshots__/_text.test.tsx.svg
+++ b/src/_tests/example_layouts/__snapshots__/_text.test.tsx.svg
@@ -1,15 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <svg width="320" height="480" xmlns="http://www.w3.org/2000/svg" version="1.1">
 
- <rect x="0" y="0" width="320" height="480" fill-opacity="0.1" stroke-width="1" stroke="black"/>
+ <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="0" width="320" height="480"/>
 
  <g transform='translate(0, 0)'>
-   <rect x="110" y="227" width="100" height="32" fill-opacity="0.1" stroke-width="1" stroke="black"/>
-
-   <g transform='translate(110, 227)'>
-     <rect x="0" y="0" width="100" height="0" fill-opacity="0.1" stroke-width="1" stroke="black"/>
-   </g>
-
+   <rect type="Text" fill-opacity="0.1" stroke-width="1" stroke="black" x="110" y="227" width="100" height="32"/>
  </g>
 
 </svg>

--- a/src/ambient.d.ts
+++ b/src/ambient.d.ts
@@ -246,6 +246,7 @@ declare module "yoga-layout" {
     setFlexDirection(direct: FlexDirection)
     setJustifyContent(justify: Justify)
     setAlignItems(alignment: number)
+    setAlignSelf(alignment: number)
 
     insertChild(node: NodeInstance, index: number)
     removeChild(node: NodeInstance)

--- a/src/component-tree-to-nodes.ts
+++ b/src/component-tree-to-nodes.ts
@@ -13,8 +13,11 @@ export const recurseTree = (component: Component, settings: Settings) => {
   if (component.children) {
     for (let index = 0; index < component.children.length; index++) {
       const childComponent = component.children[index]
-      const childNode = recurseTree(childComponent, settings)
-      node.insertChild(childNode, index)
+      // Don't go into Text nodes
+      if (!(typeof childComponent === "string")) {
+        const childNode = recurseTree(childComponent, settings)
+        node.insertChild(childNode, index)
+      }
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import * as yoga from "yoga-layout"
 export interface Component {
     type: string
     props: any
-    children: Component[] | null
+    children: Component[] | string[] | null
 }
 
 export interface RenderedComponent {
@@ -57,6 +57,7 @@ expect.extend({
 
         const settings: Settings = { width, height }
         const rootNode = componentTreeToNodeTree(root, settings)
+        if (!rootNode) { return }
 
         // This will mutate the node tree, we cannot trust that the nodes  in the original tree will
         // still exist.

--- a/src/node-to-svg.ts
+++ b/src/node-to-svg.ts
@@ -7,6 +7,7 @@ import wsp from "./whitespace"
 const nodeToSVG = (indent: number, node: RenderedComponent, settings: Settings) => {
   const layout = node.layout
   const attributes: any = {
+    "type": node.type,
     "fill-opacity": "0.1",
     "stroke-width": "1",
     "stroke": "black"
@@ -30,7 +31,7 @@ const svgRect = (x, y, w, h, settings) => {
       attributes += ` ${key}="${element}"`
     }
   }
-  return `<rect x="${x}" y="${y}" width="${w}" height="${h}"${attributes}/>`
+  return `<rect${attributes} x="${x}" y="${y}" width="${w}" height="${h}"/>`
 }
 
 export default nodeToSVG

--- a/src/reapply-layouts-to-components.ts
+++ b/src/reapply-layouts-to-components.ts
@@ -14,8 +14,11 @@ export const recurseTree = (component: Component, node: yoga.NodeInstance) => {
     for (let index = 0; index < component.children.length; index++) {
       const childComponent = component.children[index]
       const childNode = node.getChild(index)
-      const renderedChildComponent = recurseTree(childComponent, childNode)
-      newChildren.push(renderedChildComponent)
+      // Don't go into Text nodes
+      if (!(typeof childComponent === "string")) {
+        const renderedChildComponent = recurseTree(childComponent, childNode)
+        newChildren.push(renderedChildComponent)
+      }
     }
   }
 

--- a/src/tree-to-svg.ts
+++ b/src/tree-to-svg.ts
@@ -16,7 +16,10 @@ export const recurseTree =
 
       for (let index = 0; index < childrenCount; index++) {
         const child = root.children[index]
-        childGroups += recurseTree(indent + 1, child, settings)
+        // Don't go into Text nodes
+        if (!(typeof child === "string")) {
+          childGroups += recurseTree(indent + 1, child, settings)
+        }
       }
 
       return childGroups

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,9 +6,9 @@
   version "19.2.3"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-19.2.3.tgz#61748040e8589a891dfc2ec1d16a2dd74482980e"
 
-"@types/node@^7.0.15":
-  version "7.0.18"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.18.tgz#cd67f27d3dc0cfb746f0bdd5e086c4c5d55be173"
+"@types/node@^7.0.31":
+  version "7.0.31"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.31.tgz#80ea4d175599b2a00149c29a10a4eb2dff592e86"
 
 abab@^1.0.3:
   version "1.0.3"
@@ -3258,19 +3258,10 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
-nbind@^0.3.12:
+nbind@^0.3.12, nbind@^0.3.8:
   version "0.3.12"
   resolved "https://registry.yarnpkg.com/nbind/-/nbind-0.3.12.tgz#5b022d45950c1d664b360b54e6c29fa2fa5b8a59"
   dependencies:
-    emscripten-library-decorator "~0.2.2"
-    mkdirp "~0.5.1"
-    nan "^2.6.2"
-
-nbind@^0.3.8:
-  version "0.3.11"
-  resolved "https://registry.yarnpkg.com/nbind/-/nbind-0.3.11.tgz#1616e49bfee231d48381851b4ffef10b8cd47a91"
-  dependencies:
-    "@types/node" "^7.0.15"
     emscripten-library-decorator "~0.2.2"
     mkdirp "~0.5.1"
     nan "^2.6.2"


### PR DESCRIPTION
* SVGs now tell you what type the node represents
* text nodes (not components called Text) are now not drawn into the SVG
* Min width/height are now added to yoga nodes
* Some of the trickier types of style objects (ones given from style-components) are now handled correctly