### PR TITLE
Add vertical / horizontal support for margin / padding

### DIFF
--- a/src/_tests/__snapshots__/render.test.tsx-handles-some-simple-jsx.svg
+++ b/src/_tests/__snapshots__/render.test.tsx-handles-some-simple-jsx.svg
@@ -13,6 +13,14 @@
    </g>
 
    <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="20" y="80" width="20" height="20"/>
+   <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="20" y="120" width="160" height="40"/>
+
+   <g transform='translate(20, 120)'>
+     <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="20" y="0" width="10" height="10"/>
+     <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="10" y="20" width="10" height="10"/>
+     <rect type="View" fill-opacity="0.1" stroke-width="1" stroke="black" x="0" y="40" width="10" height="10"/>
+   </g>
+
  </g>
 
 </svg>

--- a/src/_tests/__snapshots__/render.test.tsx.snap
+++ b/src/_tests/__snapshots__/render.test.tsx.snap
@@ -16,6 +16,14 @@ exports[`handles some simple JSX 1`] = `
    </g>
 
    <rect type=\\"View\\" fill-opacity=\\"0.1\\" stroke-width=\\"1\\" stroke=\\"black\\" x=\\"0\\" y=\\"0\\" width=\\"NaN\\" height=\\"NaN\\"/>
+   <rect type=\\"View\\" fill-opacity=\\"0.1\\" stroke-width=\\"1\\" stroke=\\"black\\" x=\\"0\\" y=\\"0\\" width=\\"NaN\\" height=\\"NaN\\"/>
+
+   <g transform='translate(0, 0)'>
+     <rect type=\\"View\\" fill-opacity=\\"0.1\\" stroke-width=\\"1\\" stroke=\\"black\\" x=\\"0\\" y=\\"0\\" width=\\"NaN\\" height=\\"NaN\\"/>
+     <rect type=\\"View\\" fill-opacity=\\"0.1\\" stroke-width=\\"1\\" stroke=\\"black\\" x=\\"0\\" y=\\"0\\" width=\\"NaN\\" height=\\"NaN\\"/>
+     <rect type=\\"View\\" fill-opacity=\\"0.1\\" stroke-width=\\"1\\" stroke=\\"black\\" x=\\"0\\" y=\\"0\\" width=\\"NaN\\" height=\\"NaN\\"/>
+   </g>
+
  </g>
 
 </svg>

--- a/src/_tests/render.test.tsx
+++ b/src/_tests/render.test.tsx
@@ -20,6 +20,11 @@ it("handles some simple JSX", () => {
         <View style={{width: 10, height: 10, marginLeft: 20, marginTop: 10}}/>
       </View>
       <View style={{width: 20, height: 20}}/>
+      <View style={{width: 160, height: 40, marginTop: 20, paddingHorizontal: 10 }}>
+        <View style={{width: 10, height: 10, marginHorizontal: 10 }}/>
+        <View style={{width: 10, height: 10, marginVertical: 10 }}/>
+        <View style={{width: 10, height: 10, marginHorizontal: -10 }}/>
+      </View>
     </View>
   )
 

--- a/src/component-to-node.ts
+++ b/src/component-to-node.ts
@@ -24,11 +24,15 @@ const componentToNode = (component: Component, settings: Settings): yoga.NodeIns
     if (style.marginBottom) { node.setMargin(yoga.EDGE_BOTTOM, style.marginBottom) }
     if (style.marginLeft) { node.setMargin(yoga.EDGE_LEFT, style.marginLeft) }
     if (style.marginRight) { node.setMargin(yoga.EDGE_RIGHT, style.marginRight) }
+    if (style.marginVertical) { node.setMargin(yoga.EDGE_VERTICAL, style.marginVertical) }
+    if (style.marginHorizontal) { node.setMargin(yoga.EDGE_HORIZONTAL, style.marginHorizontal) }
 
     if (style.paddingTop) { node.setPadding(yoga.EDGE_TOP, style.paddingTop) }
     if (style.paddingBottom) { node.setPadding(yoga.EDGE_BOTTOM, style.paddingBottom) }
     if (style.paddingLeft) { node.setPadding(yoga.EDGE_LEFT, style.paddingLeft) }
     if (style.paddingRight) { node.setPadding(yoga.EDGE_RIGHT, style.paddingRight) }
+    if (style.paddingVertical) { node.setPadding(yoga.EDGE_VERTICAL, style.paddingVertical) }
+    if (style.paddingHorizontal) { node.setPadding(yoga.EDGE_HORIZONTAL, style.paddingHorizontal) }
 
     if (style.flex) { node.setFlex(style.flex) }
 


### PR DESCRIPTION
Support for the following RN supported style names:

* `marginVertical`
* `marginHorizontal`
* `paddingVertical`
* `paddingHorizontal`

Also changed the render test:

<img width="1269" alt="2017-06-13 11 10 15" src="https://user-images.githubusercontent.com/3001525/27089852-2d311448-508e-11e7-8ccd-fee43051144f.png">
