### PR TITLE
Add support `flexGrow`, `flexShrink`, `flexBasis`

### DIFF
--- a/src/ambient.d.ts
+++ b/src/ambient.d.ts
@@ -233,7 +233,6 @@ declare module "yoga-layout" {
   }
 
   interface NodeInstance {
-    // setFlexBasis ()
 
     setWidth(width: number)
     setHeight(height: number)
@@ -248,6 +247,9 @@ declare module "yoga-layout" {
     setPosition(edge: Edge, position: number)
 
     setFlex(ordinal: number)
+    setFlexGrow(ordinal: number)
+    setFlexShrink(ordinal: number)
+    setFlexBasis(ordinal: number)
     setFlexDirection(direct: FlexDirection)
     setJustifyContent(justify: Justify)
     setAlignItems(alignment: number)

--- a/src/component-to-node.ts
+++ b/src/component-to-node.ts
@@ -35,6 +35,9 @@ const componentToNode = (component: Component, settings: Settings): yoga.NodeIns
     if (style.paddingHorizontal) { node.setPadding(yoga.EDGE_HORIZONTAL, style.paddingHorizontal) }
 
     if (style.flex) { node.setFlex(style.flex) }
+    if (style.flexGrow) { node.setFlexGrow(style.flexGrow) }
+    if (style.flexShrink) { node.setFlexShrink(style.flexShrink) }
+    if (style.flexBasis) { node.setFlexBasis(style.flexBasis) }
 
     if (style.position === "absolute") {
       node.setPositionType(yoga.POSITION_TYPE_ABSOLUTE)


### PR DESCRIPTION
http://facebook.github.io/react-native/releases/0.47/docs/layout-props.html#flexbasis
https://facebook.github.io/yoga/docs/flex

I'm using [`styled-components/native`](https://github.com/styled-components/styled-components), the `flex` property will convert to `flexGrow`, `flexShrink`, `flexBasis` (`1` -> `1 1 0`), hopefully we could support these.