### PR TITLE
Set default font size for text block

### DIFF
--- a/src/_tests/example_layouts/__snapshots__/_text.test.tsx-renders-text-blocks.svg
+++ b/src/_tests/example_layouts/__snapshots__/_text.test.tsx-renders-text-blocks.svg
@@ -5,7 +5,7 @@
 
  <g transform='translate(0, 0)'>
    <foreignObject requiredExtensions="http://www.w3.org/1999/xhtml" x="0" y="5" width="200" height="32"><body xmlns="http://www.w3.org/1999/xhtml"><p>Hello there, here are some words</p></body></foreignObject>
-   <foreignObject requiredExtensions="http://www.w3.org/1999/xhtml" x="0" y="42" width="600" height="0"><body xmlns="http://www.w3.org/1999/xhtml"><p>here are some words that use default font size</p></body></foreignObject>
+   <foreignObject requiredExtensions="http://www.w3.org/1999/xhtml" x="0" y="42" width="600" height="28"><body xmlns="http://www.w3.org/1999/xhtml"><p>here are some words that use default font size</p></body></foreignObject>
  </g>
 
 </svg>

--- a/src/_tests/example_layouts/__snapshots__/_text.test.tsx-renders-text-blocks.svg
+++ b/src/_tests/example_layouts/__snapshots__/_text.test.tsx-renders-text-blocks.svg
@@ -5,6 +5,7 @@
 
  <g transform='translate(0, 0)'>
    <foreignObject requiredExtensions="http://www.w3.org/1999/xhtml" x="0" y="5" width="200" height="32"><body xmlns="http://www.w3.org/1999/xhtml"><p>Hello there, here are some words</p></body></foreignObject>
+   <foreignObject requiredExtensions="http://www.w3.org/1999/xhtml" x="0" y="42" width="600" height="0"><body xmlns="http://www.w3.org/1999/xhtml"><p>here are some words that use default font size</p></body></foreignObject>
  </g>
 
 </svg>

--- a/src/_tests/example_layouts/_text.test.tsx
+++ b/src/_tests/example_layouts/_text.test.tsx
@@ -17,6 +17,10 @@ it("Renders text blocks", () => {
         fontSize: 16,
         marginTop: 5,
       }}>Hello there, here are some words</Text>
+      <Text style={{
+        fontFamily: "AGaramondPro-Regular",
+        marginTop: 5,
+      }}>here are some words that use default font size</Text>
     </View>
 
   const component = renderer.create(jsx).toJSON()

--- a/src/component-to-node.ts
+++ b/src/component-to-node.ts
@@ -18,11 +18,6 @@ const componentToNode = (component: Component, settings: Settings): yoga.NodeIns
     if (style.maxHeight) { node.setMaxHeight(style.maxHeight) }
     if (style.maxWidth) { node.setMaxWidth(style.maxWidth) }
 
-    // Potentially temporary, but should at least provide some layout stubbing
-    // See https://github.com/orta/jest-snapshots-svg/issues/11 for a bit more context
-    //
-    if (!style.height && style.fontSize) { node.setHeight(style.fontSize * 2) }
-
     if (style.marginTop) { node.setMargin(yoga.EDGE_TOP, style.marginTop) }
     if (style.marginBottom) { node.setMargin(yoga.EDGE_BOTTOM, style.marginBottom) }
     if (style.marginLeft) { node.setMargin(yoga.EDGE_LEFT, style.marginLeft) }
@@ -88,13 +83,19 @@ const componentToNode = (component: Component, settings: Settings): yoga.NodeIns
 
     // We're in a node showing Text
     if (component && component.children && component.children[0] && typeof component.children[0] === "string") {
+      // Potentially temporary, but should at least provide some layout stubbing
+      // See https://github.com/orta/jest-snapshots-svg/issues/11 for a bit more context
+      //
+      const fontSize = style.fontSize || 14
+      if (!style.height) { node.setHeight(fontSize * 2) }
+
       // Skip attempting to figure the width, if it's hardcoded
       if (style.width) { return node }
       const content = component.children[0] as string
 
       // Let's say that every font is ~2 times taller than high
       const fontHeightToWidthRatio = 2
-      const guessWidth = (style.fontSize || 14) / fontHeightToWidthRatio
+      const guessWidth = fontSize / fontHeightToWidthRatio
       node.setWidth(style.width)
     }
   }


### PR DESCRIPTION
Currently if we haven't set `fontSize` to Text, the height of text block will be `0`, so I set the default font size for each Text.

We can see the svg change between the two commits:
<img width="664" alt="2017-08-24 2 23 16" src="https://user-images.githubusercontent.com/3001525/29652420-f677ecec-88d7-11e7-9309-d6564a43483e.png">
